### PR TITLE
fix for binance not included in the assert condition and return imports

### DIFF
--- a/finrl_meta/data_processors/basic_processor.py
+++ b/finrl_meta/data_processors/basic_processor.py
@@ -7,7 +7,6 @@ TIME_INTERVAL = '1D'
 
 class BasicProcessor:
     def __init__(self, data_source: str, **kwargs):
-        assert data_source in ["alpaca", "ccxt", "joinquant", "quantconnect", "ricequant", "wrds", "yahoofinance", ], "Data source input is NOT supported yet."
         self.data_source = data_source
         self.time_interval = TIME_INTERVAL
         self.time_zone = ''

--- a/finrl_meta/data_processors/processor_binance.py
+++ b/finrl_meta/data_processors/processor_binance.py
@@ -3,8 +3,7 @@ from typing import List
 import numpy as np
 import pandas as pd
 import requests
-# from talib.abstract import CCI, DX, MACD, RSI
-# from basic_processor import BasicProcessor
+from talib.abstract import CCI, DX, MACD, RSI
 from finrl_meta.data_processors.basic_processor import BasicProcessor
 
 


### PR DESCRIPTION
This fixes uncompleted listed of supported exchanges, ex: 'binance' from the assert condition. It should be removed as the same check is already handled in: https://github.com/AI4Finance-Foundation/FinRL-Meta/blob/90eb1289313f07488f2e905ae071c64441124536/finrl_meta/data_processor.py#L14

Also, re-add the technical indicators imports as they are used. I suggest integrating a PR process as some PRs introduce problems.

Regards,
ma7555