### PR TITLE
added support for 1s interval data for binance data source

### DIFF
--- a/finrl_meta/data_processor.py
+++ b/finrl_meta/data_processor.py
@@ -96,6 +96,9 @@ class DataProcessor():
     def run(self, ticker_list, start_date, end_date, time_interval, 
             technical_indicator_list, if_vix, cache=False):
         
+        if time_interval == "1s" and self.data_source != "binance":
+            raise ValueError("Currently 1s interval data is only supported with 'binance' as data source")
+
         cache_csv = '_'.join(ticker_list + [self.data_source, start_date, end_date, time_interval]) + '.csv'
         cache_dir = './cache'
         cache_path = os.path.join(cache_dir, cache_csv)

--- a/finrl_meta/data_processors/func.py
+++ b/finrl_meta/data_processors/func.py
@@ -1,5 +1,8 @@
 import datetime
 import os
+import urllib, zipfile
+from pathlib import Path
+from datetime import *
 from typing import List
 
 TIME_ZONE_SHANGHAI = 'Asia/Shanghai'  ## Hang Seng HSI, SSE, CSI
@@ -9,6 +12,7 @@ TIME_ZONE_BERLIN = 'Europe/Berlin'  # DAX, TECDAX, MDAX, SDAX
 TIME_ZONE_JAKARTA = 'Asia/Jakarta'  # LQ45
 TIME_ZONE_SELFDEFINED = 'xxx'  # If neither of the above is your time zone, you should define it, and set USE_TIME_ZONE_SELFDEFINED 1.
 USE_TIME_ZONE_SELFDEFINED = 0  # 0 (default) or 1 (use the self defined)
+BINANCE_BASE_URL = 'https://data.binance.vision/'
 
 def calc_time_zone(ticker_list: List[str], time_zone_selfdefined: str, use_time_zone_selfdefined: int) -> str:
     time_zone = ''
@@ -99,3 +103,87 @@ def date2str(dat):
 
 def str2date(str_dat):
     return datetime.datetime.strptime(str_dat, "%Y-%m-%d").date()
+
+### ticker download helpers
+
+def get_destination_dir(file_url):
+    store_directory = os.path.dirname(os.path.realpath(__file__))
+    return os.path.join(store_directory, file_url)
+
+def get_download_url(file_url):
+    return "{}{}".format(BINANCE_BASE_URL, file_url)
+
+#downloads zip, unzips zip and deltes zip
+def download_n_unzip_file(base_path, file_name, date_range=None):
+    download_path = "{}{}".format(base_path, file_name)
+    if date_range:
+        date_range = date_range.replace(" ","_")
+        base_path = os.path.join(base_path, date_range)
+
+    #raw_cache_dir = get_destination_dir("./cache/tick_raw")
+    raw_cache_dir = "./cache/tick_raw"
+    zip_save_path = os.path.join(raw_cache_dir, file_name)
+
+    csv_name = os.path.splitext(file_name)[0]+".csv"
+    csv_save_path = os.path.join(raw_cache_dir, csv_name)
+
+    fhandles = []
+
+    if os.path.exists(csv_save_path): 
+        print("\nfile already exists! {}".format(csv_save_path))
+        return [csv_save_path]
+  
+    # make the "cache" directory (only)
+    if not os.path.exists(raw_cache_dir):
+        Path(raw_cache_dir).mkdir(parents=True, exist_ok=True)
+
+    try:
+        download_url = get_download_url(download_path)
+        dl_file = urllib.request.urlopen(download_url)
+        length = dl_file.getheader('content-length')
+        if length:
+            length = int(length)
+            blocksize = max(4096,length//100)
+
+        with open(zip_save_path, 'wb') as out_file:
+            dl_progress = 0
+            print("\nFile Download: {}".format(zip_save_path))
+            while True:
+                buf = dl_file.read(blocksize)   
+                if not buf:
+                    break
+                out_file.write(buf)
+                #visuals
+                #dl_progress += len(buf)
+                #done = int(50 * dl_progress / length)
+                #sys.stdout.write("\r[%s%s]" % ('#' * done, '.' * (50-done)) )    
+                #sys.stdout.flush()
+    
+        #unzip and delete zip
+        file = zipfile.ZipFile(zip_save_path)
+        with zipfile.ZipFile(zip_save_path) as zip:
+            #guaranteed just 1 csv
+            csvpath = zip.extract(zip.namelist()[0], raw_cache_dir) 
+            fhandles.append(csvpath)
+        os.remove(zip_save_path)
+        return fhandles
+
+    except urllib.error.HTTPError:
+        print("\nFile not found: {}".format(download_url))
+        pass
+
+def convert_to_date_object(d):
+    year, month, day = [int(x) for x in d.split('-')]
+    date_obj = date(year, month, day)
+    return date_obj
+
+def get_path(trading_type, market_data_type, time_period, symbol, interval=None):
+    trading_type_path = 'data/spot'
+    #currently just supporting spot
+    if trading_type != 'spot':
+        trading_type_path = f'data/futures/{trading_type}'
+    if interval is not None:
+        path = f'{trading_type_path}/{time_period}/{market_data_type}/{symbol.upper()}/{interval}/'
+    else:
+        path = f'{trading_type_path}/{time_period}/{market_data_type}/{symbol.upper()}/'
+    return path

--- a/finrl_meta/data_processors/processor_binance.py
+++ b/finrl_meta/data_processors/processor_binance.py
@@ -1,11 +1,12 @@
-from datetime import datetime, timedelta
+import datetime as dt
 from typing import List
 import numpy as np
 import pandas as pd
 import requests
+import urllib, json
 from talib.abstract import CCI, DX, MACD, RSI
-#from basic_processor import BasicProcessor
 from finrl_meta.data_processors.basic_processor import BasicProcessor
+from .func import download_n_unzip_file, convert_to_date_object, get_path
 
 
 class BinanceProcessor(BasicProcessor):
@@ -15,22 +16,27 @@ class BinanceProcessor(BasicProcessor):
     
     #main functions
     def download_data(self, ticker_list: List[str], start_date: str, end_date: str, time_interval: str) -> pd.DataFrame:
-        startTime = datetime.strptime(start_date, '%Y-%m-%d')
-        endTime = datetime.strptime(end_date, '%Y-%m-%d')
+        startTime = dt.datetime.strptime(start_date, '%Y-%m-%d')
+        endTime = dt.datetime.strptime(end_date, '%Y-%m-%d')
         
         self.start_time = self.stringify_dates(startTime)
         self.end_time = self.stringify_dates(endTime)
         self.interval = time_interval
         self.limit = 1440
-        
-        final_df = pd.DataFrame()
-        for i in ticker_list:
-            hist_data = self.dataframe_with_limit(symbol=i)
-            df = hist_data.iloc[:-1].dropna()
-            df['tic'] = i
-            final_df = final_df.append(df)
-        
-        return final_df
+
+        #1s for now, will add support for variable time and variable tick soon
+        if time_interval == "1s":
+            # as per https://binance-docs.github.io/apidocs/spot/en/#compressed-aggregate-trades-list
+            self.limit = 1000
+            return self.fetch_n_combine(start_date, end_date, ticker_list)
+        else:
+            final_df = pd.DataFrame()
+            for i in ticker_list:
+                hist_data = self.dataframe_with_limit(symbol=i)
+                df = hist_data.iloc[:-1].dropna()
+                df['tic'] = i
+                final_df = final_df.append(df)
+            return final_df
     
 
     def clean_data(self, df):
@@ -78,7 +84,7 @@ class BinanceProcessor(BasicProcessor):
     
 
     # helper functions
-    def stringify_dates(self, date:datetime):
+    def stringify_dates(self, date:dt.datetime):
         return str(int(date.timestamp()*1000))
 
 
@@ -109,7 +115,7 @@ class BinanceProcessor(BasicProcessor):
 
         # No stock split and dividend announcement, hence adjusted close is the same as close
         df['adj_close'] = df['close']
-        df['datetime'] = df.datetime.apply(lambda x: datetime.fromtimestamp(x/1000.0))
+        df['datetime'] = df.datetime.apply(lambda x: dt.datetime.fromtimestamp(x/1000.0))
         df.reset_index(drop=True, inplace=True)
 
         return df
@@ -123,10 +129,109 @@ class BinanceProcessor(BasicProcessor):
             if new_df is None:
                 break
             final_df = final_df.append(new_df)
-            last_datetime = max(new_df.datetime) + timedelta(days=1)
+            last_datetime = max(new_df.datetime) + dt.timedelta(days=1)
             last_datetime = self.stringify_dates(last_datetime)
             
         date_value = final_df['datetime'].apply(lambda x: x.strftime('%Y-%m-%d %H:%M:%S'))
         final_df.insert(0, 'time', date_value)
         final_df.drop('datetime', inplace=True, axis=1)
         return final_df
+
+    #helpers for manipulating tick level data (1s intervals)
+    def download_daily_aggTrades(self, symbols, num_symbols, dates, start_date, end_date):
+        current = 0
+        trading_type="spot"
+        date_range = start_date + " " + end_date
+        start_date = convert_to_date_object(start_date)
+        end_date = convert_to_date_object(end_date)
+        
+        print("Found {} symbols".format(num_symbols))
+
+        map = {}
+        for symbol in symbols:
+            map[symbol] = []
+            print("[{}/{}] - start download daily {} aggTrades ".format(current+1, num_symbols, symbol))
+            for date in dates:
+                current_date = convert_to_date_object(date)
+                if current_date >= start_date and current_date <= end_date:
+                    path = get_path(trading_type, "aggTrades", "daily", symbol)
+                    file_name = "{}-aggTrades-{}.zip".format(symbol.upper(), date)
+                    fhandle = download_n_unzip_file(path, file_name, date_range)
+                    map[symbol] += fhandle
+            current += 1
+        return map
+
+    def fetch_aggTrades(self, startDate: str, endDate:str, tickers: List[str]):
+        #all valid symbols traded on v3 api
+        response = urllib.request.urlopen("https://api.binance.com/api/v3/exchangeInfo").read()
+        valid_symbols = list(map(lambda symbol: symbol['symbol'], json.loads(response)['symbols']))
+
+        for tic in tickers:
+            if tic not in valid_symbols:
+                print(tic+" not a valid ticker, removing from download")
+        tickers = list(set(tickers) & set(valid_symbols))
+        num_symbols = len(tickers)
+        #not adding tz yet
+        #for ffill missing data on starting on first day 00:00:00 (if any)
+        tminus1 = (convert_to_date_object(startDate) - dt.timedelta(1)).strftime('%Y-%m-%d')
+        dates = pd.date_range(start=tminus1, end=endDate)
+        dates = [date.strftime("%Y-%m-%d") for date in dates]
+        return self.download_daily_aggTrades(tickers, num_symbols, dates, tminus1, endDate)
+
+    #Dict[str]:List[str] -> pd.DataFrame
+    def combine_raw(self, map):
+        #same format as jingyang's current data format
+        final_df = pd.DataFrame()
+        # using AggTrades with headers from https://github.com/binance/binance-public-data/
+        colNames = ["AggregatetradeId","Price","volume","FirsttradeId","LasttradeId","time","buyerWasMaker","tradeWasBestPriceMatch"]
+        for tic in map.keys():
+            security = pd.DataFrame()
+            for i, csv in enumerate(map[tic]):
+                dailyticks = pd.read_csv(csv, 
+                                names=colNames,
+                                index_col=["time"],
+                                parse_dates=['time'], 
+                                date_parser=lambda epoch: pd.to_datetime(epoch, unit='ms'))
+                dailyfinal = dailyticks.resample('1s').agg({'Price': 'ohlc', 'volume': 'sum'})
+                dailyfinal.columns = dailyfinal.columns.droplevel(0)
+                # favor continuous series
+                #dailyfinal.dropna(inplace=True)
+
+                # implemented T-1 day ffill day start missing values 
+                # guaranteed first csv is tminus1 day
+                if i == 0:
+                    tmr = dailyfinal.index[0].date() + dt.timedelta(1)
+                    tmr_dt = dt.datetime.combine(tmr, dt.time.min)
+                    last_time_stamp_dt = dailyfinal.index[-1].to_pydatetime()
+                    s_delta = (tmr_dt-last_time_stamp_dt).seconds
+                    lastsample = dailyfinal.iloc[-1:]
+                    lastsample.index = lastsample.index.shift(s_delta, 's')
+                else:
+                    day_dt = dailyfinal.index[0].date()
+                    day_str = day_dt.strftime("%Y-%m-%d")
+                    nextday_str = (day_dt + dt.timedelta(1)).strftime("%Y-%m-%d")
+                    if dailyfinal.index[0].second != 0:
+                        #append last sample
+                        dailyfinal = lastsample.append(dailyfinal)
+                    #otherwise, just reindex and ffill
+                    dailyfinal = dailyfinal.reindex(pd.date_range(day_str, nextday_str, freq="1s")[:-1], method='ffill')
+                    #save reference info (guaranteed to be :59)
+                    lastsample = dailyfinal.iloc[-1:]
+                    lastsample.index = lastsample.index.shift(1, 's')
+                
+                    if dailyfinal.shape[0] != 86400:
+                        raise ValueError("everyday should have 86400 datapoints")
+                
+                    #only save real startDate - endDate
+                    security = security.append(dailyfinal)
+            
+            security.ffill(inplace=True)
+            security['tic'] = tic
+            final_df = final_df.append(security)
+        return final_df
+
+    def fetch_n_combine(self, startDate, endDate, tickers):
+        #return combine_raw(fetchAggTrades(startDate, endDate, tickers))
+        mapping = self.fetch_aggTrades(startDate, endDate, tickers)
+        combined_df = self.combine_raw(mapping)
+        return combined_df


### PR DESCRIPTION
currently deals with missing 1s data by forcing 86400 datapoints/day and forward filling ohlc data. considering filling missing data by using last valid close value as next ohlc in the next update. also leaving flexibility to allow a variable time interval (e.g. 2s, 5s, etc) and variable tick (e.g. grouping by every 100, 500, 1000 ticks, etc) in next update.