### PR TITLE
Vix

### DIFF
--- a/finrl_meta/data_processor.py
+++ b/finrl_meta/data_processor.py
@@ -114,17 +114,16 @@ class DataProcessor():
                 self.processor.dataframe = pickle.load(handle)
         else:
             self.download_data(ticker_list)
-            self.clean_data()
             if cache:
                 if not os.path.exists(cache_dir):
                     os.mkdir(cache_dir)
                 with open(cache_path, 'wb') as handle:
                     pickle.dump(self.dataframe, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
-
-        self.add_technical_indicator(technical_indicator_list, use_stockstats_or_talib)
         if if_vix:
             self.add_vix()
+        self.clean_data()
+        self.add_technical_indicator(technical_indicator_list, use_stockstats_or_talib)
         price_array, tech_array, turbulence_array = self.df_to_array(if_vix)
         tech_nan_positions = np.isnan(tech_array)
         tech_array[tech_nan_positions] = 0
@@ -154,11 +153,11 @@ def test_joinquant():
     ticker_list = ["000612.XSHE", "601808.XSHG"]
 
     p.download_data(ticker_list=ticker_list)
-
+    p.add_vix()
     p.clean_data()
     p.add_turbulence()
     p.add_technical_indicator(TECHNICAL_INDICATOR)
-    p.add_vix()
+
 
     price_array, tech_array, turbulence_array = p.run(ticker_list, TECHNICAL_INDICATOR, if_vix=False, cache=True)
 
@@ -191,7 +190,7 @@ def test_yfinance():
     ]
 
     technical_indicator_list = ['macd', 'rsi', 'cci', 'dx']  # self-defined technical indicator list is NOT supported yet
-    if_vix = False
+    if_vix = True
     price_array, tech_array, turbulence_array = DP.run(ticker_list, technical_indicator_list, if_vix, cache=True, use_stockstats_or_talib=1)
     print(price_array.shape, tech_array.shape)
 if __name__ == "__main__":

--- a/finrl_meta/data_processors/basic_processor.py
+++ b/finrl_meta/data_processors/basic_processor.py
@@ -113,7 +113,8 @@ class BasicProcessor:
         if self.data_source in ["alpaca", "ricequant", "tusharepro", "wrds", "yahoofinance"]:
             turbulence_index = self.calculate_turbulence()
             self.dataframe = self.dataframe.merge(turbulence_index, on="time")
-            self.dataframe.sort_values(["time", "tic"], inplace=True).reset_index(drop=True, inplace=True)
+            self.dataframe.sort_values(["time", "tic"], inplace=True)
+            self.dataframe.reset_index(drop=True, inplace=True)
 
     def calculate_turbulence(self, time_period: int = 252) -> pd.DataFrame:
         """calculate turbulence index based on dow 30"""
@@ -215,7 +216,13 @@ class BasicProcessor:
             return
 
         self.download_data([ticker])
-        self.dataframe.rename(columns={ticker: "vix"}, inplace=True)
+        vix_index = pd.DataFrame(
+            {"time": self.dataframe[self.dataframe.tic == ticker].time, "vix": self.dataframe[self.dataframe.tic == ticker].close}
+        )
+        # remove vix ticker data from dataframe
+        self.dataframe = self.dataframe[self.dataframe.tic != ticker]
+        # set the vix column
+        self.dataframe = self.dataframe.merge(vix_index, on="time")
 
 
     def df_to_array(self, tech_indicator_list: list, if_vix: bool):

--- a/finrl_meta/data_processors/basic_processor.py
+++ b/finrl_meta/data_processors/basic_processor.py
@@ -32,26 +32,7 @@ class BasicProcessor:
         pass
 
     def clean_data(self):
-        if "date" in self.dataframe.columns.values.tolist():
-            self.dataframe.rename(columns={'date': 'time'}, inplace=True)
-        if "datetime" in self.dataframe.columns.values.tolist():
-            self.dataframe.rename(columns={'datetime': 'time'}, inplace=True)
-        if self.data_source == "ccxt":
-            self.dataframe.rename(columns={'index': 'time'}, inplace=True)
-        elif self.data_source == 'ricequant':
-            ''' RiceQuant data is already cleaned, we only need to transform data format here.
-                No need for filling NaN data'''
-            self.dataframe.rename(columns={'order_book_id': 'tic'}, inplace=True)
-            # raw df uses multi-index (tic,time), reset it to single index (time)
-            self.dataframe.reset_index(level=[0, 1], inplace=True)
-            # check if there is NaN values
-            assert not self.dataframe.isnull().values.any()
-        self.dataframe.dropna(inplace=True)
-        # adj_close: adjusted close price
-        if 'adj_close' not in self.dataframe.columns.values.tolist():
-            self.dataframe['adj_close'] = self.dataframe['close']
-        self.dataframe.sort_values(by=['time', 'tic'], inplace=True)
-        self.dataframe = self.dataframe[['tic', 'time', 'open', 'high', 'low', 'close', 'adj_close', 'volume']]
+        pass
 
     def get_trading_days(self, start: str, end: str) -> List[str]:
         if self.data_source in ["binance", "ccxt", "quantconnect", "ricequant", "tusharepro"]:
@@ -232,17 +213,10 @@ class BasicProcessor:
             ticker = "vix"
         else:
             return
-        df = self.dataframe.copy()
-        self.dataframe = [ticker]
-        self.download_data(self.start, self.end, self.time_interval)
-        self.clean_data()
-        # vix = cleaned_vix[["time", "close"]]
-        # vix = vix.rename(columns={"close": "VIXY"})
-        cleaned_vix = self.dataframe.rename(columns={ticker: "vix"})
 
-        df = df.merge(cleaned_vix, on="time")
-        df = df.sort_values(["time", "tic"]).reset_index(drop=True)
-        self.dataframe = df
+        self.download_data([ticker])
+        self.dataframe.rename(columns={ticker: "vix"}, inplace=True)
+
 
     def df_to_array(self, tech_indicator_list: list, if_vix: bool):
         unique_ticker = self.dataframe.tic.unique()

--- a/finrl_meta/data_processors/processor_alpaca.py
+++ b/finrl_meta/data_processors/processor_alpaca.py
@@ -73,7 +73,14 @@ class AlpacaProcessor(BasicProcessor):
         for i in range(len(times)):
             times[i] = str(times[i])
         data_df['time'] = times"""
-        self.dataframe = data_df
+
+        # on later calls (for example for getting the vix) merge
+        if self.dataframe.empty:
+            self.dataframe = data_df
+        else:
+            self.dataframe = self.dataframe.merge(
+                data_df, on=["tic", "time"], how="left"
+            )
 
     def clean_data(self):
         df = self.dataframe.copy()

--- a/finrl_meta/data_processors/processor_alpaca.py
+++ b/finrl_meta/data_processors/processor_alpaca.py
@@ -78,7 +78,7 @@ class AlpacaProcessor(BasicProcessor):
         if self.dataframe.empty:
             self.dataframe = data_df
         else:
-            self.dataframe.append(data_df)
+            self.dataframe = self.dataframe.append(data_df)
 
     def clean_data(self):
         df = self.dataframe.copy()

--- a/finrl_meta/data_processors/processor_alpaca.py
+++ b/finrl_meta/data_processors/processor_alpaca.py
@@ -74,13 +74,11 @@ class AlpacaProcessor(BasicProcessor):
             times[i] = str(times[i])
         data_df['time'] = times"""
 
-        # on later calls (for example for getting the vix) merge
+        # on later calls (for example for getting the vix) append
         if self.dataframe.empty:
             self.dataframe = data_df
         else:
-            self.dataframe = self.dataframe.merge(
-                data_df, on=["tic", "time"], how="left"
-            )
+            self.dataframe.append(data_df)
 
     def clean_data(self):
         df = self.dataframe.copy()

--- a/finrl_meta/data_processors/processor_alpaca.py
+++ b/finrl_meta/data_processors/processor_alpaca.py
@@ -141,8 +141,8 @@ class AlpacaProcessor(BasicProcessor):
             tmp_df["tic"] = tic
             new_df = new_df.append(tmp_df)
 
-        new_df = new_df.reset_index()
-        new_df = new_df.rename(columns={"index": "time"})
+        new_df.reset_index(inplace=True)
+        new_df.rename(columns={"index": "time"}, inplace=True)
 
         print("Data clean finished!")
 
@@ -354,8 +354,8 @@ class AlpacaProcessor(BasicProcessor):
             tmp_df["tic"] = tic
             new_df = new_df.append(tmp_df)
 
-        new_df = new_df.reset_index()
-        new_df = new_df.rename(columns={"index": "time"})
+        new_df.reset_index(inplace=True)
+        new_df.rename(columns={"index": "time"}, inplace=True)
 
         df = self.add_technical_indicator(new_df, tech_indicator_list)
         df["VIXY"] = 0

--- a/finrl_meta/data_processors/processor_binance.py
+++ b/finrl_meta/data_processors/processor_binance.py
@@ -42,7 +42,7 @@ class BinanceProcessor(BasicProcessor):
         if self.dataframe.empty:
             self.dataframe = final_df
         else:
-            self.dataframe.append(final_df)
+            self.dataframe = self.dataframe.append(final_df)
 
     # def clean_data(self, df):
     #     df = df.dropna()

--- a/finrl_meta/data_processors/processor_binance.py
+++ b/finrl_meta/data_processors/processor_binance.py
@@ -38,13 +38,11 @@ class BinanceProcessor(BasicProcessor):
                 df['tic'] = i
                 final_df = final_df.append(df)
 
-        # on later calls (for example for getting the vix) merge
+        # on later calls (for example for getting the vix) append
         if self.dataframe.empty:
             self.dataframe = final_df
         else:
-            self.dataframe = self.dataframe.merge(
-                final_df, on=["tic", "time"], how="left"
-            )
+            self.dataframe.append(final_df)
 
     # def clean_data(self, df):
     #     df = df.dropna()

--- a/finrl_meta/data_processors/processor_binance.py
+++ b/finrl_meta/data_processors/processor_binance.py
@@ -133,7 +133,7 @@ class BinanceProcessor(BasicProcessor):
             df['adj_close'] = df['close']
             df['datetime'] = df.datetime.apply(lambda x: dt.datetime.fromtimestamp(x/1000.0))
             df['tic'] = symbol
-            df = df.rename(columns = {'datetime':'time'})
+            df.rename(columns = {'datetime':'time'}, inplace=True)
             df.reset_index(drop=True, inplace=True)
             merged_df = merged_df.append(df)
             

--- a/finrl_meta/data_processors/processor_binance.py
+++ b/finrl_meta/data_processors/processor_binance.py
@@ -37,7 +37,14 @@ class BinanceProcessor(BasicProcessor):
                 df = hist_data.iloc[:-1].dropna()
                 df['tic'] = i
                 final_df = final_df.append(df)
-        self.dataframe = final_df
+
+        # on later calls (for example for getting the vix) merge
+        if self.dataframe.empty:
+            self.dataframe = final_df
+        else:
+            self.dataframe = self.dataframe.merge(
+                final_df, on=["tic", "time"], how="left"
+            )
 
     # def clean_data(self, df):
     #     df = df.dropna()

--- a/finrl_meta/data_processors/processor_ccxt.py
+++ b/finrl_meta/data_processors/processor_ccxt.py
@@ -73,7 +73,7 @@ class CCXTProcessor(BasicProcessor):
                 'macd', 'boll_ub', 'boll_lb', 'rsi_30', 'dx_30',
                 'close_30_sma', 'close_60_sma']
         df = self.dataframe
-        df = df.dropna()
+        df.dropna(inplace=True)
         date_ary = df.index.values
         price_array = df[pd.MultiIndex.from_product([pair_list, ['close']])].values
         tech_array = df[pd.MultiIndex.from_product([pair_list, tech_indicator_list])].values

--- a/finrl_meta/data_processors/processor_ccxt.py
+++ b/finrl_meta/data_processors/processor_ccxt.py
@@ -37,7 +37,14 @@ class CCXTProcessor(BasicProcessor):
             temp_col = pd.MultiIndex.from_product([[ticker], ['open', 'high', 'low', 'close', 'volume']])
             dataset[temp_col] = df[['open', 'high', 'low', 'close', 'volume']].values
         print('Actual end time: ' + str(df['time'].values[-1]))
-        self.dataframe = dataset
+
+        # on later calls (for example for getting the vix) merge
+        if self.dataframe.empty:
+            self.dataframe = dataset
+        else:
+            self.dataframe = self.dataframe.merge(
+                dataset, on=["tic", "time"], how="left"
+            )
 
     # def add_technical_indicators(self, df, pair_list, tech_indicator_list = [
     #     'macd', 'boll_ub', 'boll_lb', 'rsi_30', 'dx_30',

--- a/finrl_meta/data_processors/processor_ccxt.py
+++ b/finrl_meta/data_processors/processor_ccxt.py
@@ -42,7 +42,7 @@ class CCXTProcessor(BasicProcessor):
         if self.dataframe.empty:
             self.dataframe = dataset
         else:
-            self.dataframe.append(dataset)
+            self.dataframe = self.dataframe.append(dataset)
 
     # def add_technical_indicators(self, df, pair_list, tech_indicator_list = [
     #     'macd', 'boll_ub', 'boll_lb', 'rsi_30', 'dx_30',

--- a/finrl_meta/data_processors/processor_ccxt.py
+++ b/finrl_meta/data_processors/processor_ccxt.py
@@ -38,13 +38,11 @@ class CCXTProcessor(BasicProcessor):
             dataset[temp_col] = df[['open', 'high', 'low', 'close', 'volume']].values
         print('Actual end time: ' + str(df['time'].values[-1]))
 
-        # on later calls (for example for getting the vix) merge
+        # on later calls (for example for getting the vix) append
         if self.dataframe.empty:
             self.dataframe = dataset
         else:
-            self.dataframe = self.dataframe.merge(
-                dataset, on=["tic", "time"], how="left"
-            )
+            self.dataframe.append(dataset)
 
     # def add_technical_indicators(self, df, pair_list, tech_indicator_list = [
     #     'macd', 'boll_ub', 'boll_lb', 'rsi_30', 'dx_30',

--- a/finrl_meta/data_processors/processor_iexcloud.py
+++ b/finrl_meta/data_processors/processor_iexcloud.py
@@ -100,7 +100,7 @@ class IEXCloudProcessor(BasicProcessor):
         if self.dataframe.empty:
             self.dataframe = price_data
         else:
-            self.dataframe.append(price_data)
+            self.dataframe = self.dataframe.append(price_data)
 
     def get_trading_days(self, start: str, end: str) -> List[str]:
         """Retrieves every trading day between two dates.

--- a/finrl_meta/data_processors/processor_iexcloud.py
+++ b/finrl_meta/data_processors/processor_iexcloud.py
@@ -96,7 +96,13 @@ class IEXCloudProcessor(BasicProcessor):
             )
         )
 
-        self.dataframe = price_data
+        # on later calls (for example for getting the vix) merge
+        if self.dataframe.empty:
+            self.dataframe = price_data
+        else:
+            self.dataframe = self.dataframe.merge(
+                price_data, on=["tic", "time"], how="left"
+            )
 
     def get_trading_days(self, start: str, end: str) -> List[str]:
         """Retrieves every trading day between two dates.

--- a/finrl_meta/data_processors/processor_iexcloud.py
+++ b/finrl_meta/data_processors/processor_iexcloud.py
@@ -88,7 +88,7 @@ class IEXCloudProcessor(BasicProcessor):
                 "volume",
             ]
         ]
-        price_data = price_data.rename(columns={"ticker": "tic", "date": "time", "fclose": "adj_close"})
+        price_data.rename(columns={"ticker": "tic", "date": "time", "fclose": "adj_close"}, inplace=True)
 
         price_data.date = price_data.date.map(
             lambda x: datetime.fromtimestamp(x / 1000, pytz.UTC).strftime(

--- a/finrl_meta/data_processors/processor_iexcloud.py
+++ b/finrl_meta/data_processors/processor_iexcloud.py
@@ -96,13 +96,11 @@ class IEXCloudProcessor(BasicProcessor):
             )
         )
 
-        # on later calls (for example for getting the vix) merge
+        # on later calls (for example for getting the vix) append
         if self.dataframe.empty:
             self.dataframe = price_data
         else:
-            self.dataframe = self.dataframe.merge(
-                price_data, on=["tic", "time"], how="left"
-            )
+            self.dataframe.append(price_data)
 
     def get_trading_days(self, start: str, end: str) -> List[str]:
         """Retrieves every trading day between two dates.

--- a/finrl_meta/data_processors/processor_joinquant.py
+++ b/finrl_meta/data_processors/processor_joinquant.py
@@ -35,7 +35,8 @@ class JoinquantProcessor(BasicProcessor):
             fields=["time", "open", "high", "low", "close", "volume"],
             end_dt=self.end_date,
         )
-        df = df.reset_index().rename(columns={'level_0': 'tic'})
+        df.reset_index(inplace=True)
+        df.rename(columns={'level_0': 'tic'}, inplace=True)
 
         # on later calls (for example for getting the vix) merge
         if self.dataframe.empty:

--- a/finrl_meta/data_processors/processor_joinquant.py
+++ b/finrl_meta/data_processors/processor_joinquant.py
@@ -38,13 +38,11 @@ class JoinquantProcessor(BasicProcessor):
         df.reset_index(inplace=True)
         df.rename(columns={'level_0': 'tic'}, inplace=True)
 
-        # on later calls (for example for getting the vix) merge
+        # on later calls (for example for getting the vix) append
         if self.dataframe.empty:
             self.dataframe = df
         else:
-            self.dataframe = self.dataframe.merge(
-                df, on=["tic", "time"], how="left"
-            )
+            self.dataframe.append(df)
 
     def data_fetch(self, stock_list, num, unit, end_dt):
         return jq.get_bars(security=stock_list, count=num, unit=unit,

--- a/finrl_meta/data_processors/processor_joinquant.py
+++ b/finrl_meta/data_processors/processor_joinquant.py
@@ -42,7 +42,7 @@ class JoinquantProcessor(BasicProcessor):
         if self.dataframe.empty:
             self.dataframe = df
         else:
-            self.dataframe.append(df)
+            self.dataframe = self.dataframe.append(df)
 
     def data_fetch(self, stock_list, num, unit, end_dt):
         return jq.get_bars(security=stock_list, count=num, unit=unit,

--- a/finrl_meta/data_processors/processor_joinquant.py
+++ b/finrl_meta/data_processors/processor_joinquant.py
@@ -36,7 +36,14 @@ class JoinquantProcessor(BasicProcessor):
             end_dt=self.end_date,
         )
         df = df.reset_index().rename(columns={'level_0': 'tic'})
-        self.dataframe = df
+
+        # on later calls (for example for getting the vix) merge
+        if self.dataframe.empty:
+            self.dataframe = df
+        else:
+            self.dataframe = self.dataframe.merge(
+                df, on=["tic", "time"], how="left"
+            )
 
     def data_fetch(self, stock_list, num, unit, end_dt):
         return jq.get_bars(security=stock_list, count=num, unit=unit,

--- a/finrl_meta/data_processors/processor_joinquant.py
+++ b/finrl_meta/data_processors/processor_joinquant.py
@@ -32,7 +32,7 @@ class JoinquantProcessor(BasicProcessor):
             security=ticker_list,
             count=count,
             unit=unit,
-            fields=["date", "open", "high", "low", "close", "volume"],
+            fields=["time", "open", "high", "low", "close", "volume"],
             end_dt=self.end_date,
         )
         df = df.reset_index().rename(columns={'level_0': 'tic'})
@@ -40,7 +40,7 @@ class JoinquantProcessor(BasicProcessor):
 
     def data_fetch(self, stock_list, num, unit, end_dt):
         return jq.get_bars(security=stock_list, count=num, unit=unit,
-                           fields=['date', 'open', 'high', 'low', 'close', 'volume'],
+                           fields=['time', 'open', 'high', 'low', 'close', 'volume'],
                            end_dt=end_dt)
 
     def preprocess(df, stock_list):

--- a/finrl_meta/data_processors/processor_quantconnect.py
+++ b/finrl_meta/data_processors/processor_quantconnect.py
@@ -34,7 +34,15 @@ class QuantConnectProcessor(BasicProcessor):
         for stock in ticker_list:
             qb.AddEquity(stock)
         history = qb.History(qb.Securities.Keys, self.start_date, self.end_date, self.time_interval)
-        self.dataframe = history
+
+        # on later calls (for example for getting the vix) merge
+        if self.dataframe.empty:
+            self.dataframe = history
+        else:
+            self.dataframe = self.dataframe.merge(
+                history, on=["tic", "time"], how="left"
+            )
+
 
     # def preprocess(df, stock_list):
     #     df = df[['open','high','low','close','volume']]

--- a/finrl_meta/data_processors/processor_quantconnect.py
+++ b/finrl_meta/data_processors/processor_quantconnect.py
@@ -39,7 +39,7 @@ class QuantConnectProcessor(BasicProcessor):
         if self.dataframe.empty:
             self.dataframe = history
         else:
-            self.dataframe.append(history)
+            self.dataframe = self.dataframe.append(history)
 
 
     # def preprocess(df, stock_list):

--- a/finrl_meta/data_processors/processor_quantconnect.py
+++ b/finrl_meta/data_processors/processor_quantconnect.py
@@ -35,13 +35,11 @@ class QuantConnectProcessor(BasicProcessor):
             qb.AddEquity(stock)
         history = qb.History(qb.Securities.Keys, self.start_date, self.end_date, self.time_interval)
 
-        # on later calls (for example for getting the vix) merge
+        # on later calls (for example for getting the vix) append
         if self.dataframe.empty:
             self.dataframe = history
         else:
-            self.dataframe = self.dataframe.merge(
-                history, on=["tic", "time"], how="left"
-            )
+            self.dataframe.append(history)
 
 
     # def preprocess(df, stock_list):

--- a/finrl_meta/data_processors/processor_ricequant.py
+++ b/finrl_meta/data_processors/processor_ricequant.py
@@ -18,13 +18,12 @@ class RiceQuantProcessor(BasicProcessor):
         dataframe = ricequant.get_price(ticker_list, frequency=self.time_interval,
                                         start_date=self.start_date, end_date=self.end_date)
 
-        # on later calls (for example for getting the vix) merge
+        # on later calls (for example for getting the vix) append
         if self.dataframe.empty:
             self.dataframe = dataframe
         else:
-            self.dataframe = self.dataframe.merge(
-                dataframe, on=["tic", "time"], how="left"
-            )
+            self.dataframe.append(dataframe)
+
 
     # def clean_data(self, df) -> pd.DataFrame:
     #     ''' RiceQuant data is already cleaned, we only need to transform data format here.

--- a/finrl_meta/data_processors/processor_ricequant.py
+++ b/finrl_meta/data_processors/processor_ricequant.py
@@ -22,7 +22,7 @@ class RiceQuantProcessor(BasicProcessor):
         if self.dataframe.empty:
             self.dataframe = dataframe
         else:
-            self.dataframe.append(dataframe)
+            self.dataframe = self.dataframe.append(dataframe)
 
 
     # def clean_data(self, df) -> pd.DataFrame:

--- a/finrl_meta/data_processors/processor_ricequant.py
+++ b/finrl_meta/data_processors/processor_ricequant.py
@@ -17,7 +17,14 @@ class RiceQuantProcessor(BasicProcessor):
         # download data by calling RiceQuant API
         dataframe = ricequant.get_price(ticker_list, frequency=self.time_interval,
                                         start_date=self.start_date, end_date=self.end_date)
-        self.dataframe = dataframe
+
+        # on later calls (for example for getting the vix) merge
+        if self.dataframe.empty:
+            self.dataframe = dataframe
+        else:
+            self.dataframe = self.dataframe.merge(
+                dataframe, on=["tic", "time"], how="left"
+            )
 
     # def clean_data(self, df) -> pd.DataFrame:
     #     ''' RiceQuant data is already cleaned, we only need to transform data format here.

--- a/finrl_meta/data_processors/processor_tusharepro.py
+++ b/finrl_meta/data_processors/processor_tusharepro.py
@@ -90,7 +90,13 @@ class TushareProProcessor(BasicProcessor):
 
         print("Shape of DataFrame: ", df.shape)
 
-        self.dataframe = df
+        # on later calls (for example for getting the vix) merge
+        if self.dataframe.empty:
+            self.dataframe = df
+        else:
+            self.dataframe = self.dataframe.merge(
+                df, on=["tic", "time"], how="left"
+            )
 
     def clean_data(self):
         dfc = copy.deepcopy(self.dataframe)

--- a/finrl_meta/data_processors/processor_tusharepro.py
+++ b/finrl_meta/data_processors/processor_tusharepro.py
@@ -96,7 +96,7 @@ class TushareProProcessor(BasicProcessor):
         if self.dataframe.empty:
             self.dataframe = df
         else:
-            self.dataframe.append(df)
+            self.dataframe = self.dataframe.append(df)
 
     def clean_data(self):
         dfc = copy.deepcopy(self.dataframe)

--- a/finrl_meta/data_processors/processor_tusharepro.py
+++ b/finrl_meta/data_processors/processor_tusharepro.py
@@ -78,15 +78,17 @@ class TushareProProcessor(BasicProcessor):
 
         self.df.columns = ['tic', 'date', 'open', 'high', 'low', 'close', 'pre_close', 'change', 'pct_chg', 'volume',
                            'amount']
-        self.df = self.df.sort_values(by=['date', 'tic']).reset_index(drop=True)
+        self.df.sort_values(by=['date', 'tic'], inplace=True)
+        self.df.reset_index(drop=True, inplace=True)
 
         df = self.df[['tic', 'date', 'open', 'high', 'low', 'close', 'volume']]
         df["date"] = pd.to_datetime(df["date"], format="%Y%m%d")
         df["day"] = df["date"].dt.dayofweek
         df["date"] = df.date.apply(lambda x: x.strftime("%Y-%m-%d"))
 
-        df = df.dropna()
-        df = df.sort_values(by=['date', 'tic']).reset_index(drop=True)
+        df.dropna(inplace=True)
+        df.sort_values(by=['date', 'tic'], inplace=True)
+        df.reset_index(drop=True, inplace=True)
 
         print("Shape of DataFrame: ", df.shape)
 
@@ -107,7 +109,7 @@ class TushareProProcessor(BasicProcessor):
         dfcode.tic = dfc.tic.unique()
 
         if "time" in dfc.columns.values.tolist():
-            dfc = dfc.rename(columns={'time': 'date'})
+            dfc.rename(columns={'time': 'date'}, inplace=True)
 
         dfdate.date = dfc.date.unique()
         dfdate.sort_values(by="date", ascending=False, ignore_index=True, inplace=True)
@@ -131,10 +133,11 @@ class TushareProProcessor(BasicProcessor):
             df4 = df2[df2.tic == i].fillna(method="bfill").fillna(method="ffill")
             df3 = pd.concat([df3, df4], ignore_index=True)
 
-        df3 = df3.fillna(0)
+        df3.fillna(0, inplace=True)
 
         # reshape dataframe
-        df3 = df3.sort_values(by=['date', 'tic']).reset_index(drop=True)
+        df3.sort_values(by=['date', 'tic'], inplace=True)
+        df3.reset_index(drop=True, inplace=True)
 
         print("Shape of DataFrame: ", df3.shape)
 
@@ -229,7 +232,7 @@ class TushareProProcessor(BasicProcessor):
         :return: (df) pandas dataframe
         """
         data = df[(df[target_date_col] >= start) & (df[target_date_col] < end)]
-        data = data.sort_values([target_date_col, "tic"], ignore_index=True)
+        data.sort_values([target_date_col, "tic"], ignore_index=True, inplace=True)
         data.index = data[target_date_col].factorize()[0]
         return data
 

--- a/finrl_meta/data_processors/processor_tusharepro.py
+++ b/finrl_meta/data_processors/processor_tusharepro.py
@@ -92,13 +92,11 @@ class TushareProProcessor(BasicProcessor):
 
         print("Shape of DataFrame: ", df.shape)
 
-        # on later calls (for example for getting the vix) merge
+        # on later calls (for example for getting the vix) append
         if self.dataframe.empty:
             self.dataframe = df
         else:
-            self.dataframe = self.dataframe.merge(
-                df, on=["tic", "time"], how="left"
-            )
+            self.dataframe.append(df)
 
     def clean_data(self):
         dfc = copy.deepcopy(self.dataframe)

--- a/finrl_meta/data_processors/processor_wrds.py
+++ b/finrl_meta/data_processors/processor_wrds.py
@@ -59,7 +59,7 @@ class WrdsProcessor(BasicProcessor):
         if self.dataframe.empty:
             self.dataframe = result
         else:
-            self.dataframe.append(result)
+            self.dataframe = self.dataframe.append(result)
 
     def preprocess_to_ohlcv(self, df, time_interval='60S'):
         df = df[['date', 'time_m', 'sym_root', 'size', 'price']]

--- a/finrl_meta/data_processors/processor_wrds.py
+++ b/finrl_meta/data_processors/processor_wrds.py
@@ -55,13 +55,11 @@ class WrdsProcessor(BasicProcessor):
         result.sort_values(by=['time', 'tic'], inplace=True)
         result.reset_index(drop=True, inplace=True)
 
-        # on later calls (for example for getting the vix) merge
+        # on later calls (for example for getting the vix) append
         if self.dataframe.empty:
             self.dataframe = result
         else:
-            self.dataframe = self.dataframe.merge(
-                result, on=["tic", "time"], how="left"
-            )
+            self.dataframe.append(result)
 
     def preprocess_to_ohlcv(self, df, time_interval='60S'):
         df = df[['date', 'time_m', 'sym_root', 'size', 'price']]

--- a/finrl_meta/data_processors/processor_wrds.py
+++ b/finrl_meta/data_processors/processor_wrds.py
@@ -52,8 +52,8 @@ class WrdsProcessor(BasicProcessor):
         if empty:
             raise ValueError('Empty Data under input parameters!')
         result = temp
-        result = result.sort_values(by=['time', 'tic'])
-        result = result.reset_index(drop=True)
+        result.sort_values(by=['time', 'tic'], inplace=True)
+        result.reset_index(drop=True, inplace=True)
 
         # on later calls (for example for getting the vix) merge
         if self.dataframe.empty:
@@ -108,7 +108,7 @@ class WrdsProcessor(BasicProcessor):
                 rows_1600.append(i)
 
         df = df.drop(rows_1600)
-        df = df.sort_values(by=['tic', 'time'])
+        df.sort_values(by=['tic', 'time'], inplace=True)
 
         # check missing rows
         tic_dic = {tic: [0, 0] for tic in tic_list}
@@ -150,7 +150,7 @@ class WrdsProcessor(BasicProcessor):
         assert np.isnan(np.min(ary)) == False
         # final preprocess
         df = df[['time', 'open', 'high', 'low', 'close', 'volume', 'tic']]
-        df = df.reset_index(drop=True)
+        df.reset_index(drop=True, inplace=True)
         print('Data clean finished')
         self.dataframe = df
 

--- a/finrl_meta/data_processors/processor_wrds.py
+++ b/finrl_meta/data_processors/processor_wrds.py
@@ -54,7 +54,14 @@ class WrdsProcessor(BasicProcessor):
         result = temp
         result = result.sort_values(by=['time', 'tic'])
         result = result.reset_index(drop=True)
-        self.dataframe = result
+
+        # on later calls (for example for getting the vix) merge
+        if self.dataframe.empty:
+            self.dataframe = result
+        else:
+            self.dataframe = self.dataframe.merge(
+                result, on=["tic", "time"], how="left"
+            )
 
     def preprocess_to_ohlcv(self, df, time_interval='60S'):
         df = df[['date', 'time_m', 'sym_root', 'size', 'price']]

--- a/finrl_meta/data_processors/processor_yahoofinance.py
+++ b/finrl_meta/data_processors/processor_yahoofinance.py
@@ -21,8 +21,8 @@ TIME_ZONE_USEASTERN = 'US/Eastern'  # Dow, Nasdaq, SP
 TIME_ZONE_PARIS = 'Europe/Paris'  # CAC,
 TIME_ZONE_BERLIN = 'Europe/Berlin'  # DAX, TECDAX, MDAX, SDAX
 TIME_ZONE_JAKARTA = 'Asia/Jakarta'  # LQ45
-TIME_ZONE_SELFDEFINED = 'Europe/Berlin'  # If neither of the above is your time zone, you should define it, and set USE_TIME_ZONE_SELFDEFINED 1.
-USE_TIME_ZONE_SELFDEFINED = 1  # 0 (default) or 1 (use the self defined)
+TIME_ZONE_SELFDEFINED = 'xxx'  # If neither of the above is your time zone, you should define it, and set USE_TIME_ZONE_SELFDEFINED 1.
+USE_TIME_ZONE_SELFDEFINED = 0  # 0 (default) or 1 (use the self defined)
 
 
 class YahooFinanceProcessor(BasicProcessor):
@@ -99,7 +99,7 @@ class YahooFinanceProcessor(BasicProcessor):
         if self.dataframe.empty:
             self.dataframe = data_df
         else:
-            self.dataframe.append(data_df)
+            self.dataframe = self.dataframe.append(data_df)
 
     def clean_data(self):
 

--- a/finrl_meta/data_processors/processor_yahoofinance.py
+++ b/finrl_meta/data_processors/processor_yahoofinance.py
@@ -21,8 +21,8 @@ TIME_ZONE_USEASTERN = 'US/Eastern'  # Dow, Nasdaq, SP
 TIME_ZONE_PARIS = 'Europe/Paris'  # CAC,
 TIME_ZONE_BERLIN = 'Europe/Berlin'  # DAX, TECDAX, MDAX, SDAX
 TIME_ZONE_JAKARTA = 'Asia/Jakarta'  # LQ45
-TIME_ZONE_SELFDEFINED = 'xxx'  # If neither of the above is your time zone, you should define it, and set USE_TIME_ZONE_SELFDEFINED 1.
-USE_TIME_ZONE_SELFDEFINED = 0  # 0 (default) or 1 (use the self defined)
+TIME_ZONE_SELFDEFINED = 'Europe/Berlin'  # If neither of the above is your time zone, you should define it, and set USE_TIME_ZONE_SELFDEFINED 1.
+USE_TIME_ZONE_SELFDEFINED = 1  # 0 (default) or 1 (use the self defined)
 
 
 class YahooFinanceProcessor(BasicProcessor):
@@ -95,13 +95,11 @@ class YahooFinanceProcessor(BasicProcessor):
         data_df.sort_values(by=['time', 'tic'], inplace=True)
         data_df.reset_index(drop=True, inplace=True)
 
-        # on later calls (for example for getting the vix) merge
+        # on later calls (for example for getting the vix) append
         if self.dataframe.empty:
             self.dataframe = data_df
         else:
-            self.dataframe = self.dataframe.merge(
-                data_df, on=["tic", "time"], how="left"
-            )
+            self.dataframe.append(data_df)
 
     def clean_data(self):
 


### PR DESCRIPTION
- removed the clean data code from the basic_processor because it's a duplicate. The cleaning steps are individual to each processor and should be / are done there.
- made it possible to use download_data multiple times (for vix) uses append if self.dataframe is not empty.
- changed some pandas operation to inplace
- reimplemented / prepared the add_vix function.

Tested it with yahoo finance processor. There is a problem though:
The clean_data function removes the vix column again. Wanted to fix that, the code is pretty complicate though and it's probably better the original coder of it fixes it. Also the clean_data from yahoo finance  uses backward fill? This introduces lookahead. Should be addressed too.

```
# if close on start date is NaN, fill data with first valid close
            # and set volume to 0.
```

So this PR isn't ready and needs more work. The other processor needs to be tested. It provides a solid foundation for making the vix work again though. Hope it helps.