### PR TITLE
Import platform-specific processor packages only when they're called.…

### DIFF
--- a/drl_agents/elegantrl_models.py
+++ b/drl_agents/elegantrl_models.py
@@ -6,7 +6,7 @@ from elegantrl.agents.AgentSAC import AgentSAC
 from elegantrl.agents.AgentTD3 import AgentTD3
 from elegantrl.agents.AgentA2C import AgentA2C
 from elegantrl.train.config import Arguments
-from elegantrl.train.run_tutorial import train_and_evaluate
+from elegantrl.train.run import train_and_evaluate
 
 MODELS = {"ddpg": AgentDDPG, "td3": AgentTD3, "sac": AgentSAC, "ppo": AgentPPO, "a2c": AgentA2C}
 OFF_POLICY_MODELS = ["ddpg", "td3", "sac"]

--- a/drl_agents/stablebaselines3_models.py
+++ b/drl_agents/stablebaselines3_models.py
@@ -4,8 +4,8 @@ import time
 import numpy as np
 import pandas as pd
 from finrl.apps import config
-from finrl.neo_finrl.env_stock_trading.env_stocktrading import StockTradingEnv
-from finrl.neo_finrl.preprocessor.preprocessors import data_split
+from finrl.finrl_meta.env_stock_trading.env_stocktrading import StockTradingEnv
+from finrl.finrl_meta.preprocessor.preprocessors import data_split
 from stable_baselines3 import A2C, DDPG, PPO, SAC, TD3
 from stable_baselines3.common.callbacks import BaseCallback
 from stable_baselines3.common.noise import (

--- a/finrl_meta/data_processor.py
+++ b/finrl_meta/data_processor.py
@@ -1,9 +1,3 @@
-from finrl_meta.data_processors.processor_alpaca import AlpacaProcessor as Alpaca
-from finrl_meta.data_processors.processor_wrds import WrdsProcessor as Wrds
-from finrl_meta.data_processors.processor_yahoofinance import YahooFinanceProcessor as YahooFinance
-from finrl_meta.data_processors.processor_binance import BinanceProcessor as Binance
-from finrl_meta.data_processors.processor_ricequant import RiceQuantProcessor as RiceQuant
-from finrl_meta.data_processors.processor_joinquant import JoinquantProcessor
 import pandas as pd
 import numpy as np
 
@@ -11,6 +5,7 @@ import numpy as np
 class DataProcessor():
     def __init__(self, data_source, **kwargs):
         if data_source == 'alpaca':
+            from finrl_meta.data_processors.processor_alpaca import AlpacaProcessor as Alpaca
             try:
                 API_KEY= kwargs.get('API_KEY')
                 API_SECRET= kwargs.get('API_SECRET')
@@ -20,9 +15,11 @@ class DataProcessor():
             except:
                 raise ValueError('Please input correct account info for alpaca!')
         elif data_source == "joinquant":
+            from finrl_meta.data_processors.processor_joinquant import JoinquantProcessor
             self.processor = JoinquantProcessor(data_source, **kwargs)
 
         elif data_source =='ricequant':
+            from finrl_meta.data_processors.processor_ricequant import RiceQuantProcessor as RiceQuant
             try:
                 username = kwargs.get('username')
                 password = kwargs.get('password')
@@ -31,12 +28,15 @@ class DataProcessor():
                 self.processor = RiceQuant()
                 
         elif data_source == 'wrds':
+            from finrl_meta.data_processors.processor_wrds import WrdsProcessor as Wrds
             self.processor = Wrds()
             
         elif data_source == 'yahoofinance':
+            from finrl_meta.data_processors.processor_yahoofinance import YahooFinanceProcessor as YahooFinance
             self.processor = YahooFinance()
         
         elif data_source =='binance':
+            from finrl_meta.data_processors.processor_binance import BinanceProcessor as Binance
             self.processor = Binance()
         
         else:

--- a/finrl_meta/data_processors/processor_binance.py
+++ b/finrl_meta/data_processors/processor_binance.py
@@ -20,13 +20,14 @@ class BinanceProcessor():
         self.interval = time_interval
         self.limit = 1440
         
-        final_df = pd.DataFrame()
+        df_list =[]
         for i in ticker_list:
             hist_data = self.dataframe_with_limit(symbol=i)
             df = hist_data.iloc[:-1]
             df = df.dropna()
             df['tic'] = i
-            final_df = final_df.append(df)
+            df_list.append(df)
+        final_df = pd.concat(df_list, axis=0, ignore_index=True)
         
         return final_df
     
@@ -41,14 +42,15 @@ class BinanceProcessor():
         self.tech_indicator_list = ['open', 'high', 'low', 'close', 'volume', 
                                          'macd', 'macd_signal', 'macd_hist', 
                                          'rsi', 'cci', 'dx']
-        final_df = pd.DataFrame()
+        df_list = []
         for i in df.tic.unique():
-            tic_df = df[df.tic==i] 
+            tic_df = df.loc[df.tic == i].copy()
             tic_df['macd'], tic_df['macd_signal'], tic_df['macd_hist'] = MACD(tic_df['close'], fastperiod=12, slowperiod=26, signalperiod=9)
             tic_df['rsi'] = RSI(tic_df['close'], timeperiod=14)
             tic_df['cci'] = CCI(tic_df['high'], tic_df['low'], tic_df['close'], timeperiod=14)
             tic_df['dx'] = DX(tic_df['high'], tic_df['low'], tic_df['close'], timeperiod=14)
-            final_df = final_df.append(tic_df)
+            df_list.append(tic_df)
+        final_df = pd.concat(df_list, axis=0, ignore_index=True)
         
         return final_df
     


### PR DESCRIPTION
…  Saves a lot of headaches when trying to get FinRL up and running on a clean system.  E.g. there is no need to try to import Alpaca and all its dependencies when all we need is Binance.

Small fixes
- fix lots of pandas warnings when preparing Binance data.
- rename neo_finrl to finrl_meta 
- fix location of train_and_evaluate()