### PR TITLE
Updated fillna function in base data_processor. Some changes in akshare, tushare and baostock

### DIFF
--- a/meta/data_processors/_base.py
+++ b/meta/data_processors/_base.py
@@ -94,6 +94,51 @@ class _Base:
             ]
         ]
 
+    def fillna(self):
+        df = self.dataframe
+
+        dfcode = pd.DataFrame(columns=["tic"])
+        dfdate = pd.DataFrame(columns=["time"])
+
+        dfcode.tic = df.tic.unique()
+        dfdate.time = df.time.unique()
+        dfdate.sort_values(by="time", ascending=False, ignore_index=True, inplace=True)
+
+        # the old pandas may not support pd.merge(how="cross")
+        try:
+            df1 = pd.merge(dfcode, dfdate, how="cross")
+        except:
+            print("Please wait for a few seconds...")
+            df1 = pd.DataFrame(columns=["tic", "time"])
+            for i in range(dfcode.shape[0]):
+                for j in range(dfdate.shape[0]):
+                    df1 = df1.append(
+                        pd.DataFrame(
+                            data={
+                                "tic": dfcode.iat[i, 0],
+                                "time": dfdate.iat[j, 0],
+                            },
+                            index=[(i + 1) * (j + 1) - 1],
+                        )
+                    )
+
+        df = pd.merge(df1, df, how="left", on=["tic", "time"])
+
+        # back fill missing data then front fill
+        df_new = pd.DataFrame(columns=df.columns)
+        for i in df.tic.unique():
+            df_tmp = df[df.tic == i].fillna(method="bfill").fillna(method="ffill")
+            df_new = pd.concat([df_new, df_tmp], ignore_index=True)
+
+        df_new = df_new.fillna(0)
+
+        # reshape dataframe
+        df_new = df_new.sort_values(by=["time", "tic"]).reset_index(drop=True)
+
+        print("Shape of DataFrame: ", df_new.shape)
+
+        self.dataframe = df_new
+
     def get_trading_days(self, start: str, end: str) -> List[str]:
         if self.data_source in [
             "binance",
@@ -108,8 +153,9 @@ class _Base:
             return None
 
     # select_stockstats_talib: 0 (stockstats, default), or 1 (use talib). Users can choose the method.
+    # drop_na_timestep: 0 (not dropping timesteps that contain nan), or 1 (dropping timesteps that contain nan, default). Users can choose the method.
     def add_technical_indicator(
-        self, tech_indicator_list: List[str], select_stockstats_talib: int = 0
+        self, tech_indicator_list: List[str], select_stockstats_talib: int = 0, drop_na_timesteps: int = 1,
     ):
         """
         calculate technical indicators
@@ -189,8 +235,9 @@ class _Base:
             self.dataframe = final_df
 
         self.dataframe.sort_values(by=["time", "tic"], inplace=True)
-        time_to_drop = self.dataframe[self.dataframe.isna().any(axis=1)].time.unique()
-        self.dataframe = self.dataframe[~self.dataframe.time.isin(time_to_drop)]
+        if drop_na_timesteps:
+            time_to_drop = self.dataframe[self.dataframe.isna().any(axis=1)].time.unique()
+            self.dataframe = self.dataframe[~self.dataframe.time.isin(time_to_drop)]
         print("Succesfully add technical indicators")
 
     def add_turbulence(self):

--- a/meta/data_processors/_base.py
+++ b/meta/data_processors/_base.py
@@ -34,7 +34,6 @@ from meta.config_tickers import TECDAX_TICKER
 
 
 class _Base:
-
     def __init__(
         self,
         data_source: str,
@@ -69,8 +68,7 @@ class _Base:
         if self.data_source == "ricequant":
             """RiceQuant data is already cleaned, we only need to transform data format here.
             No need for filling NaN data"""
-            self.dataframe.rename(columns={"order_book_id": "tic"},
-                                  inplace=True)
+            self.dataframe.rename(columns={"order_book_id": "tic"}, inplace=True)
             # raw df uses multi-index (tic,time), reset it to single index (time)
             self.dataframe.reset_index(level=[0, 1], inplace=True)
             # check if there is NaN values
@@ -83,16 +81,18 @@ class _Base:
         if "adjusted_close" not in self.dataframe.columns.values.tolist():
             self.dataframe["adjusted_close"] = self.dataframe["close"]
         self.dataframe.sort_values(by=["time", "tic"], inplace=True)
-        self.dataframe = self.dataframe[[
-            "tic",
-            "time",
-            "open",
-            "high",
-            "low",
-            "close",
-            "adjusted_close",
-            "volume",
-        ]]
+        self.dataframe = self.dataframe[
+            [
+                "tic",
+                "time",
+                "open",
+                "high",
+                "low",
+                "close",
+                "adjusted_close",
+                "volume",
+            ]
+        ]
 
     def fillna(self):
         df = self.dataframe
@@ -102,10 +102,7 @@ class _Base:
 
         dfcode.tic = df.tic.unique()
         dfdate.time = df.time.unique()
-        dfdate.sort_values(by="time",
-                           ascending=False,
-                           ignore_index=True,
-                           inplace=True)
+        dfdate.sort_values(by="time", ascending=False, ignore_index=True, inplace=True)
 
         # the old pandas may not support pd.merge(how="cross")
         try:
@@ -122,15 +119,15 @@ class _Base:
                                 "time": dfdate.iat[j, 0],
                             },
                             index=[(i + 1) * (j + 1) - 1],
-                        ))
+                        )
+                    )
 
         df = pd.merge(df1, df, how="left", on=["tic", "time"])
 
         # back fill missing data then front fill
         df_new = pd.DataFrame(columns=df.columns)
         for i in df.tic.unique():
-            df_tmp = df[df.tic == i].fillna(method="bfill").fillna(
-                method="ffill")
+            df_tmp = df[df.tic == i].fillna(method="bfill").fillna(method="ffill")
             df_new = pd.concat([df_new, df_tmp], ignore_index=True)
 
         df_new = df_new.fillna(0)
@@ -144,11 +141,11 @@ class _Base:
 
     def get_trading_days(self, start: str, end: str) -> List[str]:
         if self.data_source in [
-                "binance",
-                "ccxt",
-                "quantconnect",
-                "ricequant",
-                "tushare",
+            "binance",
+            "ccxt",
+            "quantconnect",
+            "ricequant",
+            "tushare",
         ]:
             print(
                 f"Calculate get_trading_days not supported for {self.data_source} yet."
@@ -190,13 +187,12 @@ class _Base:
                 indicator_df = pd.DataFrame()
                 for i in range(len(unique_ticker)):
                     try:
-                        temp_indicator = stock[stock.tic ==
-                                               unique_ticker[i]][indicator]
+                        temp_indicator = stock[stock.tic == unique_ticker[i]][indicator]
                         temp_indicator = pd.DataFrame(temp_indicator)
                         temp_indicator["tic"] = unique_ticker[i]
                         temp_indicator["time"] = self.dataframe[
-                            self.dataframe.tic ==
-                            unique_ticker[i]]["time"].to_list()
+                            self.dataframe.tic == unique_ticker[i]
+                        ]["time"].to_list()
                         indicator_df = pd.concat(
                             [indicator_df, temp_indicator],
                             axis=0,
@@ -243,10 +239,10 @@ class _Base:
 
         self.dataframe.sort_values(by=["time", "tic"], inplace=True)
         if drop_na_timesteps:
-            time_to_drop = self.dataframe[self.dataframe.isna().any(
-                axis=1)].time.unique()
-            self.dataframe = self.dataframe[~self.dataframe.time.
-                                            isin(time_to_drop)]
+            time_to_drop = self.dataframe[
+                self.dataframe.isna().any(axis=1)
+            ].time.unique()
+            self.dataframe = self.dataframe[~self.dataframe.time.isin(time_to_drop)]
         print("Succesfully add technical indicators")
 
     def add_turbulence(self):
@@ -261,34 +257,34 @@ class _Base:
         # df = df.sort_values(["time", "tic"]).reset_index(drop=True)
         # return df
         if self.data_source in [
-                "binance",
-                "ccxt",
-                "iexcloud",
-                "joinquant",
-                "quantconnect",
+            "binance",
+            "ccxt",
+            "iexcloud",
+            "joinquant",
+            "quantconnect",
         ]:
             print(
                 f"Turbulence not supported for {self.data_source} yet. Return original DataFrame."
             )
         if self.data_source in [
-                "alpaca",
-                "ricequant",
-                "tushare",
-                "wrds",
-                "yahoofinance",
+            "alpaca",
+            "ricequant",
+            "tushare",
+            "wrds",
+            "yahoofinance",
         ]:
             turbulence_index = self.calculate_turbulence()
             self.dataframe = self.dataframe.merge(turbulence_index, on="time")
-            self.dataframe.sort_values(["time", "tic"],
-                                       inplace=True).reset_index(drop=True,
-                                                                 inplace=True)
+            self.dataframe.sort_values(["time", "tic"], inplace=True).reset_index(
+                drop=True, inplace=True
+            )
 
     def calculate_turbulence(self, time_period: int = 252) -> pd.DataFrame:
         """calculate turbulence index based on dow 30"""
         # can add other market assets
-        df_price_pivot = self.dataframe.pivot(index="time",
-                                              columns="tic",
-                                              values="close")
+        df_price_pivot = self.dataframe.pivot(
+            index="time", columns="tic", values="close"
+        )
         # use returns to calculate turbulence
         df_price_pivot = df_price_pivot.pct_change()
 
@@ -299,24 +295,27 @@ class _Base:
         # turbulence_index = [0]
         count = 0
         for i in range(start, len(unique_date)):
-            current_price = df_price_pivot[df_price_pivot.index ==
-                                           unique_date[i]]
+            current_price = df_price_pivot[df_price_pivot.index == unique_date[i]]
             # use one year rolling window to calcualte covariance
             hist_price = df_price_pivot[
                 (df_price_pivot.index < unique_date[i])
-                & (df_price_pivot.index >= unique_date[i - time_period])]
+                & (df_price_pivot.index >= unique_date[i - time_period])
+            ]
             # Drop tickers which has number missing values more than the "oldest" ticker
-            filtered_hist_price = hist_price.iloc[hist_price.isna().sum().min(
-            ):].dropna(axis=1)
+            filtered_hist_price = hist_price.iloc[
+                hist_price.isna().sum().min() :
+            ].dropna(axis=1)
 
             cov_temp = filtered_hist_price.cov()
             current_temp = current_price[list(filtered_hist_price)] - np.mean(
-                filtered_hist_price, axis=0)
+                filtered_hist_price, axis=0
+            )
             # cov_temp = hist_price.cov()
             # current_temp=(current_price - np.mean(hist_price,axis=0))
 
             temp = current_temp.values.dot(np.linalg.pinv(cov_temp)).dot(
-                current_temp.values.T)
+                current_temp.values.T
+            )
             if temp > 0:
                 count += 1
                 # avoid large outlier because of the calculation just begins: else turbulence_temp = 0
@@ -325,10 +324,9 @@ class _Base:
                 turbulence_temp = 0
             turbulence_index.append(turbulence_temp)
 
-        turbulence_index = pd.DataFrame({
-            "time": df_price_pivot.index,
-            "turbulence": turbulence_index
-        })
+        turbulence_index = pd.DataFrame(
+            {"time": df_price_pivot.index, "turbulence": turbulence_index}
+        )
         return turbulence_index
 
     def add_vix(self):
@@ -338,13 +336,13 @@ class _Base:
         :return: (df) pandas dataframe
         """
         if self.data_source in [
-                "binance",
-                "ccxt",
-                "iexcloud",
-                "joinquant",
-                "quantconnect",
-                "ricequant",
-                "tushare",
+            "binance",
+            "ccxt",
+            "iexcloud",
+            "joinquant",
+            "quantconnect",
+            "ricequant",
+            "tushare",
         ]:
             print(
                 f"VIX is not applicable for {self.data_source}. Return original DataFrame"
@@ -405,29 +403,37 @@ class _Base:
 
     def df_to_array(self, tech_indicator_list: List[str], if_vix: bool):
         unique_ticker = self.dataframe.tic.unique()
-        price_array = np.column_stack([
-            self.dataframe[self.dataframe.tic == tic].close
-            for tic in unique_ticker
-        ])
+        price_array = np.column_stack(
+            [self.dataframe[self.dataframe.tic == tic].close for tic in unique_ticker]
+        )
         common_tech_indicator_list = [
-            i for i in tech_indicator_list
+            i
+            for i in tech_indicator_list
             if i in self.dataframe.columns.values.tolist()
         ]
-        tech_array = np.hstack([
-            self.dataframe.loc[(self.dataframe.tic == tic),
-                               common_tech_indicator_list]
-            for tic in unique_ticker
-        ])
+        tech_array = np.hstack(
+            [
+                self.dataframe.loc[
+                    (self.dataframe.tic == tic), common_tech_indicator_list
+                ]
+                for tic in unique_ticker
+            ]
+        )
         if if_vix:
-            risk_array = np.column_stack([
-                self.dataframe[self.dataframe.tic == tic].vix
-                for tic in unique_ticker
-            ])
+            risk_array = np.column_stack(
+                [self.dataframe[self.dataframe.tic == tic].vix for tic in unique_ticker]
+            )
         else:
-            risk_array = (np.column_stack([
-                self.dataframe[self.dataframe.tic == tic].turbulence
-                for tic in unique_ticker
-            ]) if "turbulence" in self.dataframe.columns else None)
+            risk_array = (
+                np.column_stack(
+                    [
+                        self.dataframe[self.dataframe.tic == tic].turbulence
+                        for tic in unique_ticker
+                    ]
+                )
+                if "turbulence" in self.dataframe.columns
+                else None
+            )
         print("Successfully transformed into array")
         return price_array, tech_array, risk_array
 
@@ -442,9 +448,13 @@ class _Base:
             time_intervals = ["5m", "15m", "30m", "60m", "1d", "1w", "1M"]
             assert self.time_interval in time_intervals, (
                 "This time interval is not supported. Supported time intervals: "
-                + ",".join(time_intervals))
-            if ("d" in self.time_interval or "w" in self.time_interval
-                    or "M" in self.time_interval):
+                + ",".join(time_intervals)
+            )
+            if (
+                "d" in self.time_interval
+                or "w" in self.time_interval
+                or "M" in self.time_interval
+            ):
                 return self.time_interval[-1:].lower()
             elif "m" in self.time_interval:
                 return self.time_interval[:-1]
@@ -469,7 +479,8 @@ class _Base:
             ]
             assert self.time_interval in time_intervals, (
                 "This time interval is not supported. Supported time intervals: "
-                + ",".join(time_intervals))
+                + ",".join(time_intervals)
+            )
             return self.time_interval
         elif self.data_source == "ccxt":
             pass
@@ -477,7 +488,8 @@ class _Base:
             time_intervals = ["1d"]
             assert self.time_interval in time_intervals, (
                 "This time interval is not supported. Supported time intervals: "
-                + ",".join(time_intervals))
+                + ",".join(time_intervals)
+            )
             return self.time_interval.upper()
         elif self.data_source == "joinquant":
             # '1m', '5m', '15m', '30m', '60m', '120m', '1d', '1w', '1M'
@@ -494,7 +506,8 @@ class _Base:
             ]
             assert self.time_interval in time_intervals, (
                 "This time interval is not supported. Supported time intervals: "
-                + ",".join(time_intervals))
+                + ",".join(time_intervals)
+            )
             return self.time_interval
         elif self.data_source == "quantconnect":
             pass
@@ -503,7 +516,8 @@ class _Base:
             time_intervals = ["d", "w", "M", "q", "y"]
             assert self.time_interval[-1] in time_intervals, (
                 "This time interval is not supported. Supported time intervals: "
-                + ",".join(time_intervals))
+                + ",".join(time_intervals)
+            )
             if "M" in self.time_interval:
                 return self.time_interval.lower()
             else:
@@ -514,7 +528,8 @@ class _Base:
             time_intervals = ["1d"]
             assert self.time_interval in time_intervals, (
                 "This time interval is not supported. Supported time intervals: "
-                + ",".join(time_intervals))
+                + ",".join(time_intervals)
+            )
             return self.time_interval
         elif self.data_source == "wrds":
             pass
@@ -537,7 +552,8 @@ class _Base:
             ]
             assert self.time_interval in time_intervals, (
                 "This time interval is not supported. Supported time intervals: "
-                + ",".join(time_intervals))
+                + ",".join(time_intervals)
+            )
             if "w" in self.time_interval:
                 return self.time_interval + "k"
             elif "M" in self.time_interval:

--- a/meta/data_processors/akshare.py
+++ b/meta/data_processors/akshare.py
@@ -17,7 +17,6 @@ import akshare as ak  # pip install akshare
 
 
 class Akshare(_Base):
-
     def __init__(
         self,
         data_source: str,
@@ -29,8 +28,7 @@ class Akshare(_Base):
         start_date = self.transfer_date(start_date)
         end_date = self.transfer_date(end_date)
 
-        super().__init__(data_source, start_date, end_date, time_interval,
-                         **kwargs)
+        super().__init__(data_source, start_date, end_date, time_interval, **kwargs)
 
         if "adj" in kwargs.keys():
             self.adj = kwargs["adj"]
@@ -53,9 +51,9 @@ class Akshare(_Base):
             adjust=self.adj,
         )
 
-    def download_data(self,
-                      ticker_list: List[str],
-                      save_path: str = "./data/dataset.csv"):
+    def download_data(
+        self, ticker_list: List[str], save_path: str = "./data/dataset.csv"
+    ):
         """
         `pd.DataFrame`
             7 columns: A tick symbol, time, open, high, low, close and volume
@@ -98,15 +96,17 @@ class Akshare(_Base):
         self.dataframe.sort_values(by=["time", "tic"], inplace=True)
         self.dataframe.reset_index(drop=True, inplace=True)
 
-        self.dataframe = self.dataframe[[
-            "tic", "time", "open", "high", "low", "close", "volume"
-        ]]
+        self.dataframe = self.dataframe[
+            ["tic", "time", "open", "high", "low", "close", "volume"]
+        ]
         # self.dataframe.loc[:, 'tic'] = pd.DataFrame((self.dataframe['tic'].tolist()))
-        self.dataframe["time"] = pd.to_datetime(self.dataframe["time"],
-                                                format="%Y-%m-%d")
+        self.dataframe["time"] = pd.to_datetime(
+            self.dataframe["time"], format="%Y-%m-%d"
+        )
         self.dataframe["day"] = self.dataframe["time"].dt.dayofweek
         self.dataframe["time"] = self.dataframe.time.apply(
-            lambda x: x.strftime("%Y-%m-%d"))
+            lambda x: x.strftime("%Y-%m-%d")
+        )
 
         self.dataframe.dropna(inplace=True)
         self.dataframe.sort_values(by=["time", "tic"], inplace=True)

--- a/meta/data_processors/akshare.py
+++ b/meta/data_processors/akshare.py
@@ -17,6 +17,7 @@ import akshare as ak  # pip install akshare
 
 
 class Akshare(_Base):
+
     def __init__(
         self,
         data_source: str,
@@ -28,7 +29,8 @@ class Akshare(_Base):
         start_date = self.transfer_date(start_date)
         end_date = self.transfer_date(end_date)
 
-        super().__init__(data_source, start_date, end_date, time_interval, **kwargs)
+        super().__init__(data_source, start_date, end_date, time_interval,
+                         **kwargs)
 
         if "adj" in kwargs.keys():
             self.adj = kwargs["adj"]
@@ -51,9 +53,9 @@ class Akshare(_Base):
             adjust=self.adj,
         )
 
-    def download_data(
-        self, ticker_list: List[str], save_path: str = "./data/dataset.csv"
-    ):
+    def download_data(self,
+                      ticker_list: List[str],
+                      save_path: str = "./data/dataset.csv"):
         """
         `pd.DataFrame`
             7 columns: A tick symbol, time, open, high, low, close and volume
@@ -96,17 +98,15 @@ class Akshare(_Base):
         self.dataframe.sort_values(by=["time", "tic"], inplace=True)
         self.dataframe.reset_index(drop=True, inplace=True)
 
-        self.dataframe = self.dataframe[
-            ["tic", "time", "open", "high", "low", "close", "volume"]
-        ]
+        self.dataframe = self.dataframe[[
+            "tic", "time", "open", "high", "low", "close", "volume"
+        ]]
         # self.dataframe.loc[:, 'tic'] = pd.DataFrame((self.dataframe['tic'].tolist()))
-        self.dataframe["time"] = pd.to_datetime(
-            self.dataframe["time"], format="%Y-%m-%d"
-        )
+        self.dataframe["time"] = pd.to_datetime(self.dataframe["time"],
+                                                format="%Y-%m-%d")
         self.dataframe["day"] = self.dataframe["time"].dt.dayofweek
         self.dataframe["time"] = self.dataframe.time.apply(
-            lambda x: x.strftime("%Y-%m-%d")
-        )
+            lambda x: x.strftime("%Y-%m-%d"))
 
         self.dataframe.dropna(inplace=True)
         self.dataframe.sort_values(by=["time", "tic"], inplace=True)

--- a/meta/data_processors/baostock.py
+++ b/meta/data_processors/baostock.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytz
 import yfinance as yf
+
 """Reference: https://github.com/AI4Finance-LLC/FinRL"""
 
 try:
@@ -34,7 +35,6 @@ from meta.config import (
 
 
 class Baostock(_Base):
-
     def __init__(
         self,
         data_source: str,
@@ -43,24 +43,23 @@ class Baostock(_Base):
         time_interval: str,
         **kwargs,
     ):
-        super().__init__(data_source, start_date, end_date, time_interval,
-                         **kwargs)
+        super().__init__(data_source, start_date, end_date, time_interval, **kwargs)
 
     # 日k线、周k线、月k线，以及5分钟、15分钟、30分钟和60分钟k线数据
     # ["5m", "15m", "30m", "60m", "1d", "1w", "1M"]
-    def download_data(self,
-                      ticker_list: List[str],
-                      save_path: str = "./data/dataset.csv"):
+    def download_data(
+        self, ticker_list: List[str], save_path: str = "./data/dataset.csv"
+    ):
         lg = bs.login()
         print("baostock login respond error_code:" + lg.error_code)
         print("baostock login respond  error_msg:" + lg.error_msg)
 
-        self.time_zone = calc_time_zone(ticker_list, TIME_ZONE_SELFDEFINED,
-                                        USE_TIME_ZONE_SELFDEFINED)
+        self.time_zone = calc_time_zone(
+            ticker_list, TIME_ZONE_SELFDEFINED, USE_TIME_ZONE_SELFDEFINED
+        )
         self.dataframe = pd.DataFrame()
         for ticker in ticker_list:
-            nonstandrad_ticker = self.transfer_standard_ticker_to_nonstandard(
-                ticker)
+            nonstandrad_ticker = self.transfer_standard_ticker_to_nonstandard(ticker)
             # All supported: "date,code,open,high,low,close,preclose,volume,amount,adjustflag,turn,tradestatus,pctChg,isST"
             rs = bs.query_history_k_data_plus(
                 nonstandrad_ticker,
@@ -80,8 +79,9 @@ class Baostock(_Base):
             df = pd.DataFrame(data_list, columns=rs.fields)
             df.loc[:, "code"] = [ticker] * df.shape[0]
             self.dataframe = pd.concat([self.dataframe, df])
-        self.dataframe = self.dataframe.sort_values(
-            by=["date", "code"]).reset_index(drop=True)
+        self.dataframe = self.dataframe.sort_values(by=["date", "code"]).reset_index(
+            drop=True
+        )
         bs.logout()
 
         self.dataframe.open = self.dataframe.open.astype(float)

--- a/meta/data_processors/baostock.py
+++ b/meta/data_processors/baostock.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 import pytz
 import yfinance as yf
-
 """Reference: https://github.com/AI4Finance-LLC/FinRL"""
 
 try:
@@ -35,6 +34,7 @@ from meta.config import (
 
 
 class Baostock(_Base):
+
     def __init__(
         self,
         data_source: str,
@@ -43,23 +43,24 @@ class Baostock(_Base):
         time_interval: str,
         **kwargs,
     ):
-        super().__init__(data_source, start_date, end_date, time_interval, **kwargs)
+        super().__init__(data_source, start_date, end_date, time_interval,
+                         **kwargs)
 
     # 日k线、周k线、月k线，以及5分钟、15分钟、30分钟和60分钟k线数据
     # ["5m", "15m", "30m", "60m", "1d", "1w", "1M"]
-    def download_data(
-        self, ticker_list: List[str], save_path: str = "./data/dataset.csv"
-    ):
+    def download_data(self,
+                      ticker_list: List[str],
+                      save_path: str = "./data/dataset.csv"):
         lg = bs.login()
         print("baostock login respond error_code:" + lg.error_code)
         print("baostock login respond  error_msg:" + lg.error_msg)
 
-        self.time_zone = calc_time_zone(
-            ticker_list, TIME_ZONE_SELFDEFINED, USE_TIME_ZONE_SELFDEFINED
-        )
+        self.time_zone = calc_time_zone(ticker_list, TIME_ZONE_SELFDEFINED,
+                                        USE_TIME_ZONE_SELFDEFINED)
         self.dataframe = pd.DataFrame()
         for ticker in ticker_list:
-            nonstandrad_ticker = self.transfer_standard_ticker_to_nonstandard(ticker)
+            nonstandrad_ticker = self.transfer_standard_ticker_to_nonstandard(
+                ticker)
             # All supported: "date,code,open,high,low,close,preclose,volume,amount,adjustflag,turn,tradestatus,pctChg,isST"
             rs = bs.query_history_k_data_plus(
                 nonstandrad_ticker,
@@ -79,9 +80,8 @@ class Baostock(_Base):
             df = pd.DataFrame(data_list, columns=rs.fields)
             df.loc[:, "code"] = [ticker] * df.shape[0]
             self.dataframe = pd.concat([self.dataframe, df])
-        self.dataframe = self.dataframe.sort_values(by=["date", "code"]).reset_index(
-            drop=True
-        )
+        self.dataframe = self.dataframe.sort_values(
+            by=["date", "code"]).reset_index(drop=True)
         bs.logout()
 
         self.dataframe.open = self.dataframe.open.astype(float)

--- a/meta/data_processors/baostock.py
+++ b/meta/data_processors/baostock.py
@@ -84,6 +84,10 @@ class Baostock(_Base):
         )
         bs.logout()
 
+        self.dataframe.open = self.dataframe.open.astype(float)
+        self.dataframe.high = self.dataframe.high.astype(float)
+        self.dataframe.low = self.dataframe.low.astype(float)
+        self.dataframe.close = self.dataframe.close.astype(float)
         self.save_data(save_path)
 
         print(

--- a/meta/data_processors/tushare.py
+++ b/meta/data_processors/tushare.py
@@ -37,8 +37,7 @@ class Tushare(_Base):
         time_interval: str,
         **kwargs,
     ):
-        super().__init__(data_source, start_date, end_date, time_interval,
-                         **kwargs)
+        super().__init__(data_source, start_date, end_date, time_interval, **kwargs)
         assert "token" in kwargs.keys(), "Please input token!"
         self.token = kwargs["token"]
         if "adj" in kwargs.keys():
@@ -58,9 +57,9 @@ class Tushare(_Base):
             adj=self.adj,
         )
 
-    def download_data(self,
-                      ticker_list: List[str],
-                      save_path: str = "./data/dataset.csv"):
+    def download_data(
+        self, ticker_list: List[str], save_path: str = "./data/dataset.csv"
+    ):
         """
         `pd.DataFrame`
             7 columns: A tick symbol, time, open, high, low, close and volume
@@ -96,15 +95,15 @@ class Tushare(_Base):
         self.dataframe.sort_values(by=["time", "tic"], inplace=True)
         self.dataframe.reset_index(drop=True, inplace=True)
 
-        self.dataframe = self.dataframe[[
-            "tic", "time", "open", "high", "low", "close", "volume"
-        ]]
+        self.dataframe = self.dataframe[
+            ["tic", "time", "open", "high", "low", "close", "volume"]
+        ]
         # self.dataframe.loc[:, 'tic'] = pd.DataFrame((self.dataframe['tic'].tolist()))
-        self.dataframe["time"] = pd.to_datetime(self.dataframe["time"],
-                                                format="%Y%m%d")
+        self.dataframe["time"] = pd.to_datetime(self.dataframe["time"], format="%Y%m%d")
         self.dataframe["day"] = self.dataframe["time"].dt.dayofweek
         self.dataframe["time"] = self.dataframe.time.apply(
-            lambda x: x.strftime("%Y-%m-%d"))
+            lambda x: x.strftime("%Y-%m-%d")
+        )
 
         self.dataframe.dropna(inplace=True)
         self.dataframe.sort_values(by=["time", "tic"], inplace=True)
@@ -156,8 +155,9 @@ class Tushare(_Base):
         assert ".csv" in path  # only support csv format now
         self.dataframe = pd.read_csv(path)
         columns = self.dataframe.columns
-        assert ("tic" in columns and "time" in columns and "close" in columns
-                )  # input file must have "tic","time" and "close" columns
+        assert (
+            "tic" in columns and "time" in columns and "close" in columns
+        )  # input file must have "tic","time" and "close" columns
 
 
 class ReturnPlotter:
@@ -191,11 +191,11 @@ class ReturnPlotter:
         if baseline_ticket:
             # 使用指定ticket作为baseline
             baseline_df = self.get_baseline(baseline_ticket)
-            baseline_date_list = baseline_df.time.dt.strftime(
-                "%Y-%m-%d").tolist()
+            baseline_date_list = baseline_df.time.dt.strftime("%Y-%m-%d").tolist()
             df_date_list = self.df_account_value.time.tolist()
             df_account_value = self.df_account_value[
-                self.df_account_value.time.isin(baseline_date_list)]
+                self.df_account_value.time.isin(baseline_date_list)
+            ]
             baseline_df = baseline_df[baseline_df.time.isin(df_date_list)]
             baseline = baseline_df.close.tolist()
             baseline_label = tic2label.get(baseline_ticket, baseline_ticket)
@@ -205,8 +205,7 @@ class ReturnPlotter:
             all_date = self.trade.time.unique().tolist()
             baseline = []
             for day in all_date:
-                day_close = self.trade[self.trade["time"] ==
-                                       day].close.tolist()
+                day_close = self.trade[self.trade["time"] == day].close.tolist()
                 avg_close = sum(day_close) / len(day_close)
                 baseline.append(avg_close)
             ours = self.df_account_value.account_value.tolist()
@@ -219,15 +218,11 @@ class ReturnPlotter:
         )
         time = list(range(len(ours)))
         datetimes = self.df_account_value.time.tolist()
-        ticks = [
-            tick for t, tick in zip(time, datetimes) if t % days_per_tick == 0
-        ]
+        ticks = [tick for t, tick in zip(time, datetimes) if t % days_per_tick == 0]
         plt.title("Cumulative Returns")
         plt.plot(time, ours, label="DDPG Agent", color="green")
         plt.plot(time, baseline, label=baseline_label, color="grey")
-        plt.xticks([i * days_per_tick for i in range(len(ticks))],
-                   ticks,
-                   fontsize=7)
+        plt.xticks([i * days_per_tick for i in range(len(ticks))], ticks, fontsize=7)
 
         plt.xlabel("Date")
         plt.ylabel("Cumulative Return")
@@ -254,9 +249,8 @@ class ReturnPlotter:
 
         # find intersection
         all_date = sorted(
-            list(
-                set(df_date_list) & set(csi300_date_list)
-                & set(sh50_date_list)))
+            list(set(df_date_list) & set(csi300_date_list) & set(sh50_date_list))
+        )
 
         # filter data
         csi300_df = csi300_df[csi300_df.time.isin(all_date)]
@@ -275,7 +269,8 @@ class ReturnPlotter:
             baseline_equal_weight.append(avg_close)
 
         df_account_value = self.df_account_value[
-            self.df_account_value.time.isin(all_date)]
+            self.df_account_value.time.isin(all_date)
+        ]
         ours = df_account_value.account_value.tolist()
 
         ours = self.pct(ours)
@@ -288,9 +283,7 @@ class ReturnPlotter:
         )
         time = list(range(len(ours)))
         datetimes = self.df_account_value.time.tolist()
-        ticks = [
-            tick for t, tick in zip(time, datetimes) if t % days_per_tick == 0
-        ]
+        ticks = [tick for t, tick in zip(time, datetimes) if t % days_per_tick == 0]
         plt.title("Cumulative Returns")
         plt.plot(time, ours, label="DDPG Agent", color="darkorange")
         plt.plot(
@@ -299,18 +292,14 @@ class ReturnPlotter:
             label=baseline_label,
             color="cornflowerblue",
         )  # equal weight
-        plt.plot(time,
-                 baseline_300,
-                 label=baseline_label_300,
-                 color="lightgreen")  # 399300
-        plt.plot(time, baseline_50, label=baseline_label_50,
-                 color="silver")  # 000016
+        plt.plot(
+            time, baseline_300, label=baseline_label_300, color="lightgreen"
+        )  # 399300
+        plt.plot(time, baseline_50, label=baseline_label_50, color="silver")  # 000016
         plt.xlabel("Date")
         plt.ylabel("Cumulative Return")
 
-        plt.xticks([i * days_per_tick for i in range(len(ticks))],
-                   ticks,
-                   fontsize=7)
+        plt.xticks([i * days_per_tick for i in range(len(ticks))], ticks, fontsize=7)
         plt.legend()
         plt.show()
         plt.savefig("./plot_all.png")

--- a/meta/data_processors/tushare.py
+++ b/meta/data_processors/tushare.py
@@ -37,7 +37,8 @@ class Tushare(_Base):
         time_interval: str,
         **kwargs,
     ):
-        super().__init__(data_source, start_date, end_date, time_interval, **kwargs)
+        super().__init__(data_source, start_date, end_date, time_interval,
+                         **kwargs)
         assert "token" in kwargs.keys(), "Please input token!"
         self.token = kwargs["token"]
         if "adj" in kwargs.keys():
@@ -57,9 +58,9 @@ class Tushare(_Base):
             adj=self.adj,
         )
 
-    def download_data(
-        self, ticker_list: List[str], save_path: str = "./data/dataset.csv"
-    ):
+    def download_data(self,
+                      ticker_list: List[str],
+                      save_path: str = "./data/dataset.csv"):
         """
         `pd.DataFrame`
             7 columns: A tick symbol, time, open, high, low, close and volume
@@ -95,15 +96,15 @@ class Tushare(_Base):
         self.dataframe.sort_values(by=["time", "tic"], inplace=True)
         self.dataframe.reset_index(drop=True, inplace=True)
 
-        self.dataframe = self.dataframe[
-            ["tic", "time", "open", "high", "low", "close", "volume"]
-        ]
+        self.dataframe = self.dataframe[[
+            "tic", "time", "open", "high", "low", "close", "volume"
+        ]]
         # self.dataframe.loc[:, 'tic'] = pd.DataFrame((self.dataframe['tic'].tolist()))
-        self.dataframe["time"] = pd.to_datetime(self.dataframe["time"], format="%Y%m%d")
+        self.dataframe["time"] = pd.to_datetime(self.dataframe["time"],
+                                                format="%Y%m%d")
         self.dataframe["day"] = self.dataframe["time"].dt.dayofweek
         self.dataframe["time"] = self.dataframe.time.apply(
-            lambda x: x.strftime("%Y-%m-%d")
-        )
+            lambda x: x.strftime("%Y-%m-%d"))
 
         self.dataframe.dropna(inplace=True)
         self.dataframe.sort_values(by=["time", "tic"], inplace=True)
@@ -155,9 +156,8 @@ class Tushare(_Base):
         assert ".csv" in path  # only support csv format now
         self.dataframe = pd.read_csv(path)
         columns = self.dataframe.columns
-        assert (
-            "tic" in columns and "time" in columns and "close" in columns
-        )  # input file must have "tic","time" and "close" columns
+        assert ("tic" in columns and "time" in columns and "close" in columns
+                )  # input file must have "tic","time" and "close" columns
 
 
 class ReturnPlotter:
@@ -191,11 +191,11 @@ class ReturnPlotter:
         if baseline_ticket:
             # 使用指定ticket作为baseline
             baseline_df = self.get_baseline(baseline_ticket)
-            baseline_date_list = baseline_df.time.dt.strftime("%Y-%m-%d").tolist()
+            baseline_date_list = baseline_df.time.dt.strftime(
+                "%Y-%m-%d").tolist()
             df_date_list = self.df_account_value.time.tolist()
             df_account_value = self.df_account_value[
-                self.df_account_value.time.isin(baseline_date_list)
-            ]
+                self.df_account_value.time.isin(baseline_date_list)]
             baseline_df = baseline_df[baseline_df.time.isin(df_date_list)]
             baseline = baseline_df.close.tolist()
             baseline_label = tic2label.get(baseline_ticket, baseline_ticket)
@@ -205,7 +205,8 @@ class ReturnPlotter:
             all_date = self.trade.time.unique().tolist()
             baseline = []
             for day in all_date:
-                day_close = self.trade[self.trade["time"] == day].close.tolist()
+                day_close = self.trade[self.trade["time"] ==
+                                       day].close.tolist()
                 avg_close = sum(day_close) / len(day_close)
                 baseline.append(avg_close)
             ours = self.df_account_value.account_value.tolist()
@@ -218,11 +219,15 @@ class ReturnPlotter:
         )
         time = list(range(len(ours)))
         datetimes = self.df_account_value.time.tolist()
-        ticks = [tick for t, tick in zip(time, datetimes) if t % days_per_tick == 0]
+        ticks = [
+            tick for t, tick in zip(time, datetimes) if t % days_per_tick == 0
+        ]
         plt.title("Cumulative Returns")
         plt.plot(time, ours, label="DDPG Agent", color="green")
         plt.plot(time, baseline, label=baseline_label, color="grey")
-        plt.xticks([i * days_per_tick for i in range(len(ticks))], ticks, fontsize=7)
+        plt.xticks([i * days_per_tick for i in range(len(ticks))],
+                   ticks,
+                   fontsize=7)
 
         plt.xlabel("Date")
         plt.ylabel("Cumulative Return")
@@ -249,8 +254,9 @@ class ReturnPlotter:
 
         # find intersection
         all_date = sorted(
-            list(set(df_date_list) & set(csi300_date_list) & set(sh50_date_list))
-        )
+            list(
+                set(df_date_list) & set(csi300_date_list)
+                & set(sh50_date_list)))
 
         # filter data
         csi300_df = csi300_df[csi300_df.time.isin(all_date)]
@@ -269,8 +275,7 @@ class ReturnPlotter:
             baseline_equal_weight.append(avg_close)
 
         df_account_value = self.df_account_value[
-            self.df_account_value.time.isin(all_date)
-        ]
+            self.df_account_value.time.isin(all_date)]
         ours = df_account_value.account_value.tolist()
 
         ours = self.pct(ours)
@@ -283,7 +288,9 @@ class ReturnPlotter:
         )
         time = list(range(len(ours)))
         datetimes = self.df_account_value.time.tolist()
-        ticks = [tick for t, tick in zip(time, datetimes) if t % days_per_tick == 0]
+        ticks = [
+            tick for t, tick in zip(time, datetimes) if t % days_per_tick == 0
+        ]
         plt.title("Cumulative Returns")
         plt.plot(time, ours, label="DDPG Agent", color="darkorange")
         plt.plot(
@@ -292,14 +299,18 @@ class ReturnPlotter:
             label=baseline_label,
             color="cornflowerblue",
         )  # equal weight
-        plt.plot(
-            time, baseline_300, label=baseline_label_300, color="lightgreen"
-        )  # 399300
-        plt.plot(time, baseline_50, label=baseline_label_50, color="silver")  # 000016
+        plt.plot(time,
+                 baseline_300,
+                 label=baseline_label_300,
+                 color="lightgreen")  # 399300
+        plt.plot(time, baseline_50, label=baseline_label_50,
+                 color="silver")  # 000016
         plt.xlabel("Date")
         plt.ylabel("Cumulative Return")
 
-        plt.xticks([i * days_per_tick for i in range(len(ticks))], ticks, fontsize=7)
+        plt.xticks([i * days_per_tick for i in range(len(ticks))],
+                   ticks,
+                   fontsize=7)
         plt.legend()
         plt.show()
         plt.savefig("./plot_all.png")


### PR DESCRIPTION
* Base Data_processor
  * Add `fillna` function in base data_processor.
  * Add `drop_na_timesteps` parameter in the `add_technical_indicator` function in base data_processor so that we can choose whether to drop the timesteps that contain Nan. The default is **the same as the past** that drop the timesteps that contain Nan

* Akshare: removed `clean_data` and `add_technical_indicator` functions
* Tushare: removed `clean_data` and `add_technical_indicator` functions
* Baostock: change `open`, `high`, `low`, and `close` columns to float in case they are objects