### PR TITLE
Update yahoofinance.py for the clean_data: "1Min" to "1m"

### DIFF
--- a/meta/data_processors/yahoofinance.py
+++ b/meta/data_processors/yahoofinance.py
@@ -95,7 +95,7 @@ class Yahoofinance(_Base):
         trading_days = self.get_trading_days(start=self.start_date, end=self.end_date)
         if time_interval == "1D":
             times = trading_days
-        elif time_interval == "1Min":
+        elif time_interval == "1m":
             times = []
             for day in trading_days:
                 current_time = pd.Timestamp(day + " 09:30:00").tz_localize(


### PR DESCRIPTION
The accepted time intervals for Yahoo Finance are: ["1m", "2m", "5m", "15m", "30m", "60m", "90m", "1h", "1d", "5d", "1w", "1M", "3M"]. However, this statement in yahoofinance.py still asks for "1Min", resulting in a ValueError: Data cleaned at the given time interval is not supported for Yahoo Finance data.