### PR TITLE
Add synthetic OHLCV data generator for testing (closes #70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ OHLCV: open, high, low, and close prices; volume
 
 adjusted_close: adjusted close price
 
+**Synthetic data for testing:** `meta/data_processors/synthetic.py` provides `generate_synthetic_data()`, which generates idealized synthetic price series (sine wave, trend, random walk) in the standard OHLCV schema above — no API keys or network access required. This is useful for quickly testing/debugging a new environment or agent, or for pre-training on simple patterns before moving to real, noisier market data ([#70](https://github.com/AI4Finance-Foundation/FinRL-Meta/issues/70)).
+
+```python
+from meta.data_processors.synthetic import generate_synthetic_data
+
+df = generate_synthetic_data(
+    tic_list=["SYN1", "SYN2"],
+    start_date="2021-01-01",
+    end_date="2021-06-01",
+    pattern="random_walk",  # or "sine", "trend"
+    seed=42,
+)
+```
+
 Technical indicators users can add: 'macd', 'boll_ub', 'boll_lb', 'rsi_30', 'dx_30', 'close_30_sma', 'close_60_sma'. Users also can add their features.
 
 

--- a/meta/data_processors/synthetic.py
+++ b/meta/data_processors/synthetic.py
@@ -1,0 +1,165 @@
+"""Synthetic OHLCV data generator for FinRL-Meta.
+
+Generates idealized synthetic price series (sine wave, trend, random walk)
+in FinRL-Meta's standard OHLCV schema. Useful for quickly testing/debugging
+trading environments and agents without needing to download real market
+data, and for pre-training agents on simple patterns before exposing them
+to real, noisier data.
+
+See discussion: https://github.com/AI4Finance-Foundation/FinRL-Meta/issues/70
+"""
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
+STANDARD_COLUMNS = [
+    "tic",
+    "time",
+    "open",
+    "high",
+    "low",
+    "close",
+    "adjusted_close",
+    "volume",
+]
+
+SUPPORTED_PATTERNS = ["sine", "trend", "random_walk"]
+
+
+class SyntheticDataGenerator:
+    """Generates synthetic OHLCV price series in FinRL-Meta's standard schema:
+    ['tic', 'time', 'open', 'high', 'low', 'close', 'adjusted_close', 'volume']
+    """
+
+    def __init__(self, seed: Optional[int] = None):
+        self.rng = np.random.default_rng(seed)
+
+    def _base_series(
+        self,
+        n_steps: int,
+        pattern: str,
+        start_price: float,
+        trend: float,
+        amplitude: float,
+        period: int,
+        noise_std: float,
+    ) -> np.ndarray:
+        t = np.arange(n_steps)
+        if pattern == "sine":
+            base = start_price + amplitude * np.sin(2 * np.pi * t / period)
+        elif pattern == "trend":
+            base = start_price + trend * t
+        elif pattern == "random_walk":
+            steps = self.rng.normal(loc=trend, scale=amplitude, size=n_steps)
+            base = start_price + np.cumsum(steps)
+        else:
+            raise ValueError(
+                f"Unknown pattern '{pattern}'. Supported patterns: {SUPPORTED_PATTERNS}"
+            )
+        noise = self.rng.normal(loc=0.0, scale=noise_std, size=n_steps)
+        series = base + noise
+        # prices must stay strictly positive
+        series = np.clip(series, a_min=0.01, a_max=None)
+        return series
+
+    def generate(
+        self,
+        tic_list: List[str],
+        start_date: str,
+        end_date: str,
+        time_interval: str = "1d",
+        pattern: str = "random_walk",
+        start_price: float = 100.0,
+        trend: float = 0.05,
+        amplitude: float = 1.0,
+        period: int = 20,
+        noise_std: float = 0.5,
+    ) -> pd.DataFrame:
+        """Generate a synthetic OHLCV DataFrame matching FinRL-Meta's standard schema.
+
+        :param tic_list: list of ticker symbols to generate independent series for
+        :param start_date: 'YYYY-MM-DD'
+        :param end_date: 'YYYY-MM-DD'
+        :param time_interval: currently only '1d' (daily) is supported
+        :param pattern: one of 'sine', 'trend', 'random_walk'
+        :param start_price: starting close price for each ticker
+        :param trend: drift per step (used by 'trend' and 'random_walk')
+        :param amplitude: sine wave amplitude, or random_walk step std dev
+        :param period: sine wave period, in steps
+        :param noise_std: std dev of additive Gaussian noise on top of the base pattern
+        :return: DataFrame with columns [tic, time, open, high, low, close, adjusted_close, volume]
+        """
+        if time_interval != "1d":
+            raise NotImplementedError(
+                "SyntheticDataGenerator currently only supports time_interval='1d'."
+            )
+
+        dates = pd.bdate_range(start=start_date, end=end_date)  # business days
+        n_steps = len(dates)
+        if n_steps == 0:
+            raise ValueError("start_date/end_date produced zero trading days.")
+
+        frames = []
+        for tic in tic_list:
+            close = self._base_series(
+                n_steps, pattern, start_price, trend, amplitude, period, noise_std
+            )
+            daily_range = np.abs(
+                self.rng.normal(loc=0.0, scale=noise_std / 2, size=n_steps)
+            )
+            high = close + daily_range
+            low = np.clip(close - daily_range, a_min=0.01, a_max=None)
+            open_ = np.concatenate([[close[0]], close[:-1]])
+            volume = self.rng.integers(low=1_000, high=100_000, size=n_steps)
+
+            frames.append(
+                pd.DataFrame(
+                    {
+                        "tic": tic,
+                        "time": dates.strftime("%Y-%m-%d"),
+                        "open": open_,
+                        "high": high,
+                        "low": low,
+                        "close": close,
+                        "adjusted_close": close,
+                        "volume": volume,
+                    }
+                )
+            )
+
+        df = pd.concat(frames, ignore_index=True)
+        df.sort_values(by=["time", "tic"], inplace=True)
+        df.reset_index(drop=True, inplace=True)
+        return df[STANDARD_COLUMNS]
+
+
+def generate_synthetic_data(
+    tic_list: List[str],
+    start_date: str,
+    end_date: str,
+    time_interval: str = "1d",
+    pattern: str = "random_walk",
+    seed: Optional[int] = None,
+    **kwargs,
+) -> pd.DataFrame:
+    """Convenience function wrapping SyntheticDataGenerator.generate()."""
+    return SyntheticDataGenerator(seed=seed).generate(
+        tic_list=tic_list,
+        start_date=start_date,
+        end_date=end_date,
+        time_interval=time_interval,
+        pattern=pattern,
+        **kwargs,
+    )
+
+
+if __name__ == "__main__":
+    df = generate_synthetic_data(
+        tic_list=["SYN1", "SYN2"],
+        start_date="2020-01-01",
+        end_date="2020-03-01",
+        pattern="sine",
+        seed=42,
+    )
+    print(df.head())

--- a/meta/data_processors/synthetic.py
+++ b/meta/data_processors/synthetic.py
@@ -1,14 +1,12 @@
-"""Synthetic OHLCV data generator for FinRL-Meta.
-
-Generates idealized synthetic price series (sine wave, trend, random walk)
-in FinRL-Meta's standard OHLCV schema. Useful for quickly testing/debugging
-trading environments and agents without needing to download real market
-data, and for pre-training agents on simple patterns before exposing them
-to real, noisier data.
-
-See discussion: https://github.com/AI4Finance-Foundation/FinRL-Meta/issues/70
-"""
-
+# Synthetic OHLCV data generator for FinRL-Meta.
+#
+# Generates idealized synthetic price series (sine wave, trend, random walk)
+# in FinRL-Meta's standard OHLCV schema. Useful for quickly testing/debugging
+# trading environments and agents without needing to download real market
+# data, and for pre-training agents on simple patterns before exposing them
+# to real, noisier data.
+#
+# See discussion: https://github.com/AI4Finance-Foundation/FinRL-Meta/issues/70
 from typing import List
 from typing import Optional
 

--- a/meta/data_processors/synthetic.py
+++ b/meta/data_processors/synthetic.py
@@ -8,7 +8,9 @@ to real, noisier data.
 
 See discussion: https://github.com/AI4Finance-Foundation/FinRL-Meta/issues/70
 """
-from typing import List, Optional
+
+from typing import List
+from typing import Optional
 
 import numpy as np
 import pandas as pd

--- a/unit_tests/test_synthetic.py
+++ b/unit_tests/test_synthetic.py
@@ -5,7 +5,16 @@ import pytest
 from meta.data_processors.synthetic import generate_synthetic_data
 from meta.data_processors.synthetic import SUPPORTED_PATTERNS
 
-EXPECTED_COLUMNS = ["tic", "time", "open", "high", "low", "close", "adjusted_close", "volume"]
+EXPECTED_COLUMNS = [
+    "tic",
+    "time",
+    "open",
+    "high",
+    "low",
+    "close",
+    "adjusted_close",
+    "volume",
+]
 
 
 class TestSyntheticDataGenerator:

--- a/unit_tests/test_synthetic.py
+++ b/unit_tests/test_synthetic.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from meta.data_processors.synthetic import generate_synthetic_data
+from meta.data_processors.synthetic import SUPPORTED_PATTERNS
+
+EXPECTED_COLUMNS = ["tic", "time", "open", "high", "low", "close", "adjusted_close", "volume"]
+
+
+class TestSyntheticDataGenerator:
+    @pytest.mark.parametrize("pattern", SUPPORTED_PATTERNS)
+    def test_generate_returns_expected_schema(self, pattern: str) -> None:
+        df = generate_synthetic_data(
+            tic_list=["SYN1"],
+            start_date="2021-01-01",
+            end_date="2021-02-01",
+            pattern=pattern,
+            seed=1,
+        )
+        assert isinstance(df, pd.DataFrame)
+        assert list(df.columns) == EXPECTED_COLUMNS
+        assert not df.empty
+        assert (df["close"] > 0).all()
+
+    def test_multiple_tickers_are_independent(self) -> None:
+        df = generate_synthetic_data(
+            tic_list=["SYN1", "SYN2"],
+            start_date="2021-01-01",
+            end_date="2021-02-01",
+            pattern="random_walk",
+            seed=2,
+        )
+        assert set(df["tic"].unique()) == {"SYN1", "SYN2"}
+        series_1 = df[df.tic == "SYN1"]["close"].to_numpy()
+        series_2 = df[df.tic == "SYN2"]["close"].to_numpy()
+        assert not np.allclose(series_1, series_2)
+
+    def test_seed_reproducibility(self) -> None:
+        kwargs = dict(
+            tic_list=["SYN1"],
+            start_date="2021-01-01",
+            end_date="2021-02-01",
+            pattern="random_walk",
+            seed=42,
+        )
+        df1 = generate_synthetic_data(**kwargs)
+        df2 = generate_synthetic_data(**kwargs)
+        pd.testing.assert_frame_equal(df1, df2)
+
+    def test_trend_pattern_increases_on_average(self) -> None:
+        df = generate_synthetic_data(
+            tic_list=["SYN1"],
+            start_date="2021-01-01",
+            end_date="2021-06-01",
+            pattern="trend",
+            trend=1.0,
+            noise_std=0.01,
+            seed=3,
+        )
+        close = df["close"].to_numpy()
+        assert close[-1] > close[0]
+
+    def test_unknown_pattern_raises(self) -> None:
+        with pytest.raises(ValueError):
+            generate_synthetic_data(
+                tic_list=["SYN1"],
+                start_date="2021-01-01",
+                end_date="2021-01-10",
+                pattern="not_a_real_pattern",
+            )
+
+    def test_unsupported_time_interval_raises(self) -> None:
+        with pytest.raises(NotImplementedError):
+            generate_synthetic_data(
+                tic_list=["SYN1"],
+                start_date="2021-01-01",
+                end_date="2021-01-10",
+                time_interval="1h",
+            )


### PR DESCRIPTION
## Summary
Implements the suggestion in #70: a synthetic price series generator to use as a helper/environment data source for quickly testing agents/environments, or for pre-training on idealized patterns before real market data.

- Adds `meta/data_processors/synthetic.py` with `generate_synthetic_data()` (and the underlying `SyntheticDataGenerator` class), producing OHLCV data in FinRL-Meta's standard schema (`tic, time, open, high, low, close, adjusted_close, volume`).
- Supports three patterns as requested in the issue: `sine` (sine wave), `trend` (linear drift), and `random_walk` (Gaussian random walk), each with configurable noise (`noise_std`), amplitude/step size, and a `seed` for reproducibility.
- No network access or API keys required — fully offline/deterministic given a seed.
- Adds `unit_tests/test_synthetic.py` (8 tests, all passing locally): schema validation, multi-ticker independence, seed reproducibility, trend direction, and error handling for unknown patterns / unsupported time intervals.
- Adds a short "Synthetic data for testing" section to the README with a usage example, right after the Supported Data Sources table.

Kept this as a standalone, self-contained module rather than wiring it into the `DataSource` enum / `_Base` download machinery, to keep the change small and non-invasive — happy to extend it to full `DataProcessor` integration in a follow-up if maintainers prefer that shape.

## Test plan
- [x] `python -m pytest unit_tests/test_synthetic.py -v` — 8/8 passing
- [x] Manually verified generated DataFrame shape/columns and that `close` stays positive across all three patterns
- [x] Confirmed issue #70 is still open with no other PR addressing it

Closes #70